### PR TITLE
Add Interpret: natural-language expansion layer for ChatParser

### DIFF
--- a/Console/Chat.class.php
+++ b/Console/Chat.class.php
@@ -28,7 +28,7 @@ class Chat extends Command {
 		$output->writeln('');
 
 		while (true) {
-			$line = readline("\033[36mfrogman>\033[0m ");
+			$line = readline('frogman> ');
 			if ($line === false) break; // Ctrl+D
 
 			$line = trim($line);

--- a/Frogman.class.php
+++ b/Frogman.class.php
@@ -2338,7 +2338,7 @@ class Frogman extends \FreePBX_Helpers implements \BMO {
 		}
 		foreach (glob($dir . '/*.php') as $file) {
 			$basename = basename($file, '.php');
-			if ($basename === 'AbstractTool' || $basename === 'ChatParser') {
+			if ($basename === 'AbstractTool' || $basename === 'ChatParser' || $basename === 'Interpret') {
 				continue;
 			}
 			require_once $file;

--- a/Tools/ChatParser.php
+++ b/Tools/ChatParser.php
@@ -1,6 +1,10 @@
 <?php
 namespace FreePBX\modules\Frogman;
 
+if (!class_exists(__NAMESPACE__ . '\\Interpret', false)) {
+	require_once realpath(__DIR__ . '/Interpret.php');
+}
+
 class ChatParser {
 
 	private static $db = null;
@@ -1657,6 +1661,21 @@ class ChatParser {
 		// ── Shorthand: just a number = get extension ──
 		if (preg_match('/^(\d{3,6})$/', $msg, $m)) {
 			return ['tool' => 'fm_get_extension', 'params' => ['ext' => $m[1]]];
+		}
+		
+		// ── Interpretation Layer ──
+		// Strip filler, normalise phrasing. If it changes the input,
+		// re-parse the normalised form. Off-switchable via kvstore key
+		// 'frogman_interpret_mode'.
+		if (!$skipFuzzy) {
+			$expanded = Interpret::expand($msg);
+			if (is_string($expanded) && $expanded !== $msg) {
+				$result = self::parse($expanded, $sessionId, true);
+				if (is_array($result) && isset($result['tool']) && !isset($result['interpreted_as'])) {
+					$result['interpreted_as'] = $expanded;
+				}
+				return $result;
+			}
 		}
 
 		// ── Fuzzy Intent Matching ──

--- a/Tools/ChatParser.php
+++ b/Tools/ChatParser.php
@@ -1674,11 +1674,18 @@ class ChatParser {
 		// re-parse the normalised form. Off-switchable via kvstore key
 		// 'frogman_interpret_mode'.
 		if (!$skipFuzzy) {
-			$expanded = Interpret::expand($msg);
-			if (is_string($expanded) && $expanded !== $msg) {
+			$interpreted = Interpret::interpret($msg);
+			if (is_array($interpreted) && !empty($interpreted['text']) && $interpreted['text'] !== $msg) {
+				$expanded = $interpreted['text'];
+				if (!Interpret::shouldRun($interpreted)) {
+					return ['response' => Interpret::rephrasePrompt($msg, $expanded)];
+				}
 				$result = self::parse($expanded, $sessionId, true);
 				if (is_array($result) && isset($result['tool']) && !isset($result['interpreted_as'])) {
 					$result['interpreted_as'] = $expanded;
+				}
+				if (is_array($result) && isset($result['response']) && strpos($result['response'], "don't understand") !== false) {
+					return ['response' => Interpret::rephrasePrompt($msg, $expanded)];
 				}
 				return $result;
 			}

--- a/Tools/ChatParser.php
+++ b/Tools/ChatParser.php
@@ -173,7 +173,7 @@ class ChatParser {
 
 		// Apply user input to current step (if any)
 		if ($userInput !== null) {
-			if (preg_match('/^(cancel|abort|stop)$/i', $userInput)) {
+			if (preg_match('/^(cancel|abort|stop)$/i', $userInput) || Interpret::isCorrectionCancel($userInput)) {
 				self::clearPending($sessionId);
 				return ['response' => 'Cancelled.'];
 			}
@@ -393,11 +393,17 @@ class ChatParser {
 		$inputPending = self::getInputPending($sessionId);
 		if ($inputPending) {
 			$isSkip = (bool)preg_match('/^(no|cancel|skip|nevermind|nope|abort)$/i', $msg);
+			$isCorrectionCancel = Interpret::isCorrectionCancel($msg);
 			$isWizard = ($inputPending['type'] ?? 'input') === 'wizard';
 			$isMacro = ($inputPending['type'] ?? 'input') === 'macro';
 
 			if ($isMacro) {
 				return self::advanceMacro($sessionId, $msg);
+			}
+
+			if ($isCorrectionCancel) {
+				self::clearPending($sessionId);
+				return ['response' => 'OK, cancelled. Try again with the command you want.'];
 			}
 
 			if ($isWizard) {
@@ -461,7 +467,7 @@ class ChatParser {
 			$pending['params']['confirm'] = true;
 			return ['tool' => $pending['tool'], 'params' => $pending['params']];
 		}
-		if ($pending && preg_match('/^(no|n|cancel|nevermind|nope|nah|abort)$/i', $msg)) {
+		if ($pending && (preg_match('/^(no|n|cancel|nevermind|nope|nah|abort)$/i', $msg) || Interpret::isCorrectionCancel($msg))) {
 			self::clearPending($sessionId);
 			$isFollowUp = !empty($pending['type']) && $pending['type'] === 'followup';
 			return ['response' => $isFollowUp ? 'OK, no problem.' : 'Cancelled.'];

--- a/Tools/Interpret.php
+++ b/Tools/Interpret.php
@@ -269,6 +269,7 @@ class Interpret {
 		return [
 			['pattern' => '/\b(please|pls|plz)\b/i', 'replacement' => '', 'confidence' => 0.80, 'reason' => 'inline politeness'],
 			['pattern' => '/\b(for\s+me|if\s+you\s+can)\b/i', 'replacement' => '', 'confidence' => 0.80, 'reason' => 'inline politeness'],
+			['pattern' => '/\b(show|list|get)\s+the\s+/i', 'replacement' => '$1 ', 'confidence' => 0.82, 'reason' => 'article stripping'],
 		];
 	}
 

--- a/Tools/Interpret.php
+++ b/Tools/Interpret.php
@@ -188,7 +188,7 @@ class Interpret {
         self::applyRuleGroup($work, self::phrasalVerbRules(), $confidence, $risk, $reasons);
 
         $before = $work;
-        $work = preg_replace('/^\s*(create|add|new|delete|remove|disable|drop)\s+(\d{3,6})\s*$/i', '$1 extension $2', $work);
+        $work = preg_replace('/^\s*(create|add|new|delete|remove|disable|drop)\s+(\d{3,6})(.*)$/i', '$1 extension $2$3', $work);
         if ($work !== $before) {
 	    self::markRewrite($confidence, $risk, $reasons, 0.96, self::RISK_WRITE, 'numeric extension shorthand');
         }

--- a/Tools/Interpret.php
+++ b/Tools/Interpret.php
@@ -269,7 +269,6 @@ class Interpret {
 		return [
 			['pattern' => '/\b(please|pls|plz)\b/i', 'replacement' => '', 'confidence' => 0.80, 'reason' => 'inline politeness'],
 			['pattern' => '/\b(for\s+me|if\s+you\s+can)\b/i', 'replacement' => '', 'confidence' => 0.80, 'reason' => 'inline politeness'],
-			['pattern' => '/\b(show|list|get)\s+the\s+/i', 'replacement' => '$1 ', 'confidence' => 0.82, 'reason' => 'article stripping'],
 		];
 	}
 
@@ -301,6 +300,7 @@ class Interpret {
 	private static function viewerPhraseRules() {
 		return [
 			['pattern' => '/^\s*(show|get|check)\s+me\s+/i', 'replacement' => '$1 ', 'confidence' => 0.91, 'risk' => self::RISK_READ, 'reason' => 'viewer phrase'],
+            ['pattern' => '/^\s*(show|list|get)\s+the\s+/i', 'replacement' => '$1 ', 'confidence' => 0.91, 'risk' => self::RISK_READ, 'reason' => 'article stripping'],
 			['pattern' => '/^\s*(what\'?s|what\s+is)\s+(?:the\s+)?(ext|extension)\s+(\d{3,6})\s*$/i', 'replacement' => 'show extension $3', 'confidence' => 0.91, 'risk' => self::RISK_READ, 'reason' => 'viewer phrase'],
 			['pattern' => '/^\s*(ext|extension)\s+(\d{3,6})\s*$/i', 'replacement' => 'show extension $2', 'confidence' => 0.91, 'risk' => self::RISK_READ, 'reason' => 'viewer phrase'],
 			['pattern' => '/^\s*(who\'?s|who\s+is)\s+on\s+(?:the\s+)?phone\s*$/i', 'replacement' => 'who is on the phone', 'confidence' => 0.91, 'risk' => self::RISK_READ, 'reason' => 'viewer phrase'],

--- a/Tools/Interpret.php
+++ b/Tools/Interpret.php
@@ -188,9 +188,9 @@ class Interpret {
         self::applyRuleGroup($work, self::phrasalVerbRules(), $confidence, $risk, $reasons);
 
         $before = $work;
-        $work = preg_replace('/^\s*(delete|remove|disable|drop)\s+(\d{3,6})\s*$/i', '$1 extension $2', $work);
+        $work = preg_replace('/^\s*(create|add|new|delete|remove|disable|drop)\s+(\d{3,6})\s*$/i', '$1 extension $2', $work);
         if ($work !== $before) {
-	    self::markRewrite($confidence, $risk, $reasons, 0.96, self::RISK_WRITE, 'numeric extension delete shorthand');
+	    self::markRewrite($confidence, $risk, $reasons, 0.96, self::RISK_WRITE, 'numeric extension shorthand');
         }
 
         // 3. Intent rewrites. These are stricter, usually anchored, and should
@@ -301,12 +301,13 @@ class Interpret {
 	private static function scoreCommandShape($msg) {
 		$work = trim($msg);
 		$shapes = [
-			['pattern' => '/^(?:show|get|check|list|who\s+is|current\s+calls|help)\b/i', 'confidence' => 0.90, 'risk' => self::RISK_READ, 'reason' => 'read command shape'],
-			['pattern' => '/^(?:health|diagnose|troubleshoot)\b/i', 'confidence' => 0.88, 'risk' => self::RISK_READ, 'reason' => 'diagnostic command shape'],
-			['pattern' => '/^(?:enable|disable|set|clear|forward|configure)\b/i', 'confidence' => 0.90, 'risk' => self::RISK_STATE, 'reason' => 'state command shape'],
-			['pattern' => '/^(?:create|add|new|rename|update)\b/i', 'confidence' => 0.89, 'risk' => self::RISK_WRITE, 'reason' => 'write command shape'],
-			['pattern' => '/^(?:delete|remove|drop|disable)\s+(?:ext|extension)\s+\d{3,6}$/i', 'confidence' => 0.96, 'risk' => self::RISK_WRITE, 'reason' => 'known extension removal command shape'],
-		];
+	    ['pattern' => '/^(?:create|add|new)\s+(?:ext|extension)\s+\d{3,6}$/i', 'confidence' => 0.96, 'risk' => self::RISK_WRITE, 'reason' => 'known extension creation command shape'],
+	    ['pattern' => '/^(?:delete|remove|drop|disable)\s+(?:ext|extension)\s+\d{3,6}$/i', 'confidence' => 0.96, 'risk' => self::RISK_WRITE, 'reason' => 'known extension removal command shape'],
+	    ['pattern' => '/^(?:show|get|check|list|who\s+is|current\s+calls|help)\b/i', 'confidence' => 0.90, 'risk' => self::RISK_READ, 'reason' => 'read command shape'],
+	    ['pattern' => '/^(?:health|diagnose|troubleshoot)\b/i', 'confidence' => 0.88, 'risk' => self::RISK_READ, 'reason' => 'diagnostic command shape'],
+	    ['pattern' => '/^(?:enable|disable|set|clear|forward|configure)\b/i', 'confidence' => 0.90, 'risk' => self::RISK_STATE, 'reason' => 'state command shape'],
+	    ['pattern' => '/^(?:create|add|new|rename|update)\b/i', 'confidence' => 0.89, 'risk' => self::RISK_WRITE, 'reason' => 'write command shape'],
+        ];
 		foreach ($shapes as $shape) {
 			if (preg_match($shape['pattern'], $work)) {
 				return $shape;

--- a/Tools/Interpret.php
+++ b/Tools/Interpret.php
@@ -301,7 +301,7 @@ class Interpret {
 	private static function scoreCommandShape($msg) {
 		$work = trim($msg);
 		$shapes = [
-	    ['pattern' => '/^(?:create|add|new)\s+(?:ext|extension)\s+\d{3,6}$/i', 'confidence' => 0.96, 'risk' => self::RISK_WRITE, 'reason' => 'known extension creation command shape'],
+	    ['pattern' => '/^(?:create|add|new)\s+(?:ext|extension)\s+\d{3,6}(?:\s+(?:for|named?)\s+.+)?$/i', 'confidence' => 0.96, 'risk' => self::RISK_WRITE, 'reason' => 'known extension creation command shape'],
 	    ['pattern' => '/^(?:delete|remove|drop|disable)\s+(?:ext|extension)\s+\d{3,6}$/i', 'confidence' => 0.96, 'risk' => self::RISK_WRITE, 'reason' => 'known extension removal command shape'],
 	    ['pattern' => '/^(?:show|get|check|list|who\s+is|current\s+calls|help)\b/i', 'confidence' => 0.90, 'risk' => self::RISK_READ, 'reason' => 'read command shape'],
 	    ['pattern' => '/^(?:health|diagnose|troubleshoot)\b/i', 'confidence' => 0.88, 'risk' => self::RISK_READ, 'reason' => 'diagnostic command shape'],

--- a/Tools/Interpret.php
+++ b/Tools/Interpret.php
@@ -286,7 +286,8 @@ class Interpret {
 		// from scoreCommandShape() to clear shouldRun()'s threshold.
 		return [
 			['pattern' => '/\b(have\s+a\s+look\s+at|take\s+a\s+look\s+at|look\s+at)\b/i', 'replacement' => 'show', 'confidence' => 0.72, 'risk' => self::RISK_UNKNOWN, 'reason' => 'phrasal verb'],
-			['pattern' => '/\b(get\s+me|pull\s+up|bring\s+up|find\s+me)\b/i', 'replacement' => 'show', 'confidence' => 0.72, 'risk' => self::RISK_UNKNOWN, 'reason' => 'phrasal verb'],
+			['pattern' => '/\b(see|view|display)\b/i', 'replacement' => 'show', 'confidence' => 0.72, 'risk' => self::RISK_UNKNOWN, 'reason' => 'phrasal verb'],
+            ['pattern' => '/\b(get\s+me|pull\s+up|bring\s+up|find\s+me)\b/i', 'replacement' => 'show', 'confidence' => 0.72, 'risk' => self::RISK_UNKNOWN, 'reason' => 'phrasal verb'],
 			['pattern' => '/\b(sort\s+out|deal\s+with|take\s+care\s+of)\b/i', 'replacement' => 'fix', 'confidence' => 0.72, 'risk' => self::RISK_UNKNOWN, 'reason' => 'phrasal verb'],
 			['pattern' => '/\b(spin\s+up|stand\s+up|provision)\b/i', 'replacement' => 'create', 'confidence' => 0.72, 'risk' => self::RISK_UNKNOWN, 'reason' => 'phrasal verb'],
 			['pattern' => '/\b(decommission|retire)\b/i', 'replacement' => 'delete', 'confidence' => 0.72, 'risk' => self::RISK_UNKNOWN, 'reason' => 'phrasal verb'],

--- a/Tools/Interpret.php
+++ b/Tools/Interpret.php
@@ -21,6 +21,7 @@ namespace FreePBX\modules\Frogman;
  * Parser helper only: this is not an AbstractTool and must not be
  * auto-registered as a callable Frogman tool.
  */
+if (!class_exists(__NAMESPACE__ . '\\Interpret', false)) {
 class Interpret {
 
 	const MODE_OFF = 'off';
@@ -241,4 +242,5 @@ class Interpret {
 		$work = preg_replace('/[.,]+(?=\s|$)/', ' ', $work);
 		return $work;
 	}
+}
 }

--- a/Tools/Interpret.php
+++ b/Tools/Interpret.php
@@ -26,6 +26,10 @@ class Interpret {
 
 	const MODE_OFF = 'off';
 	const MODE_LOCAL = 'local';
+	const RISK_READ = 'read';
+	const RISK_WRITE = 'write';
+	const RISK_STATE = 'state';
+	const RISK_UNKNOWN = 'unknown';
 	// Reserved for future use: MODE_REMOTE
 
 	/**
@@ -36,14 +40,46 @@ class Interpret {
 	 *   - null:   couldn't help. ChatParser falls through to fuzzy matching.
 	 */
 	public static function expand($msg) {
+		$result = self::interpret($msg);
+		if ($result && self::shouldRun($result)) {
+			return $result['text'];
+		}
+		return null;
+	}
+
+	/**
+	 * Structured interpretation result for ChatParser.
+	 *
+	 * Returns null when Interpret has no useful change. Otherwise:
+	 *   text       => normalised command text
+	 *   confidence => deterministic confidence score, 0.0-1.0
+	 *   risk       => read/write/state/unknown
+	 *   reason     => short explanation for audit/debug/review
+	 */
+	public static function interpret($msg) {
 		$mode = self::getMode();
 		if ($mode === self::MODE_OFF) {
 			return null;
 		}
 		if ($mode === self::MODE_LOCAL) {
-			return self::expandLocal($msg);
+			return self::interpretLocal($msg);
 		}
 		return null;
+	}
+
+	public static function shouldRun($result) {
+		if (!is_array($result) || empty($result['text'])) {
+			return false;
+		}
+		$confidence = (float)($result['confidence'] ?? 0);
+		$risk = $result['risk'] ?? self::RISK_UNKNOWN;
+		$thresholds = [
+			self::RISK_READ => 0.78,
+			self::RISK_WRITE => 0.88,
+			self::RISK_STATE => 0.90,
+			self::RISK_UNKNOWN => 0.95,
+		];
+		return $confidence >= ($thresholds[$risk] ?? $thresholds[self::RISK_UNKNOWN]);
 	}
 
 	/**
@@ -77,6 +113,20 @@ class Interpret {
 	}
 
 	/**
+	 * Response used when a rewrite changed the input but still did not land on
+	 * a strict parser command. This is a low-confidence interpretation, so ask
+	 * the user to rephrase instead of guessing.
+	 */
+	public static function rephrasePrompt($original, $expanded = null) {
+		$original = trim((string)$original);
+		$expanded = trim((string)$expanded);
+		if ($expanded !== '' && strcasecmp($expanded, $original) !== 0) {
+			return "I tried reading that as `{$expanded}`, but I'm not sure what command you want. Please rephrase.";
+		}
+		return "I'm not sure what command you want. Please rephrase.";
+	}
+
+	/**
 	 * Read the interpret mode from Frogman's FreePBX module config store.
 	 * Defaults to 'local'.
 	 * Admins can disable by setting it to 'off'.
@@ -100,9 +150,12 @@ class Interpret {
 	 * Each transformation is deliberately anchored so it only fires when
 	 * we're confident it's an instruction, not a casual mention.
 	 */
-	private static function expandLocal($msg) {
+	private static function interpretLocal($msg) {
 		$original = $msg;
 		$work = $msg;
+		$confidence = 0.70;
+		$risk = self::RISK_READ;
+		$reasons = [];
 
 		// 1. Strip politeness and filler from the START of the message only.
 		//    Anchored so "show me just the failed calls" doesn't lose "just".
@@ -112,21 +165,42 @@ class Interpret {
 			'/^\s*(i\s+need\s+to|i\s+want\s+to|i\s+would\s+like\s+to|i\'?d\s+like\s+to)\s+/i',
 			'/^\s*just\s+/i',
 		];
+		$before = $work;
 		$work = preg_replace($leading, '', $work);
+		if ($work !== $before) {
+			$confidence = max($confidence, 0.82);
+			$reasons[] = 'leading request wrapper';
+		}
 
 		// 2. Strip mid-sentence politeness or tone markers that are always safe to drop.
 		$inline = [
 			'/\b(please|pls|plz)\b/i',
 			'/\b(for\s+me|if\s+you\s+can)\b/i',
 		];
+		$before = $work;
 		$work = preg_replace($inline, '', $work);
+		if ($work !== $before) {
+			$confidence = max($confidence, 0.80);
+			$reasons[] = 'inline politeness';
+		}
 
 		// 2a. Strip rude/urgent/emotional phrasing so we can recover the real command.
+		$before = $work;
 		$work = self::expandTonePhrases($work);
+		if ($work !== $before) {
+			$confidence = max($confidence, $work === 'help' ? 0.93 : 0.78);
+			$risk = $work === 'help' ? self::RISK_READ : $risk;
+			$reasons[] = 'tone wrapper';
+		}
 
 		// 2b. Strip trailing urgency/tone markers that otherwise get captured as
 		// names or labels by strict parser patterns.
+		$before = $work;
 		$work = self::stripTrailingTone($work);
+		if ($work !== $before) {
+			$confidence = max($confidence, 0.84);
+			$reasons[] = 'trailing urgency';
+		}
 
 		// 2c. Normalise common spellings before intent rewrites.
 		$spellings = [
@@ -135,7 +209,12 @@ class Interpret {
 			'/\bfollow\s+me\b/i' => 'followme',
 		];
 		foreach ($spellings as $pattern => $replacement) {
+			$before = $work;
 			$work = preg_replace($pattern, $replacement, $work);
+			if ($work !== $before) {
+				$confidence = max($confidence, 0.86);
+				$reasons[] = 'spelling normalisation';
+			}
 		}
 
 		// 3. Phrasal verbs → single-word equivalents the strict patterns know.
@@ -151,7 +230,13 @@ class Interpret {
 			'/\b(reboot|bounce|cycle)\b/i'                                  => 'restart',
 		];
 		foreach ($phrasals as $pattern => $replacement) {
+			$before = $work;
 			$work = preg_replace($pattern, $replacement, $work);
+			if ($work !== $before) {
+				$confidence = max($confidence, 0.72);
+				$risk = self::RISK_UNKNOWN;
+				$reasons[] = 'phrasal verb';
+			}
 		}
 
 		// 3a. Viewer phrasing that maps cleanly to existing strict anchors.
@@ -163,13 +248,25 @@ class Interpret {
 			'/^\s*(current|live)\s+call\s+activity\s*$/i' => 'current calls',
 		];
 		foreach ($viewPhrases as $pattern => $replacement) {
+			$before = $work;
 			$work = preg_replace($pattern, $replacement, $work);
+			if ($work !== $before) {
+				$confidence = max($confidence, 0.91);
+				$risk = self::RISK_READ;
+				$reasons[] = 'viewer phrase';
+			}
 		}
 
 		// 4. State-of-the-user phrases -> PBX actions.
 		//    Anchored to "<extension> is <state>" so bare "sick" or "left"
 		//    in unrelated phrases doesn't fire.
+		$before = $work;
 		$work = self::expandStatePhrases($work);
+		if ($work !== $before) {
+			$confidence = max($confidence, 0.94);
+			$risk = self::RISK_STATE;
+			$reasons[] = 'extension state phrase';
+		}
 
 		// 4a. Remove conversational punctuation without damaging values like
 		// emails, IPs, phone numbers, or channel names.
@@ -183,7 +280,35 @@ class Interpret {
 
 		// Only return if we changed something meaningful.
 		if ($work !== '' && $work !== $original) {
-			return $work;
+			$shape = self::scoreCommandShape($work);
+			if ($shape) {
+				$confidence = max($confidence, $shape['confidence']);
+				$risk = $shape['risk'];
+				$reasons[] = $shape['reason'];
+			}
+			return [
+				'text' => $work,
+				'confidence' => min(1.0, $confidence),
+				'risk' => $risk,
+				'reason' => implode(', ', array_unique($reasons)),
+			];
+		}
+		return null;
+	}
+
+	private static function scoreCommandShape($msg) {
+		$work = trim($msg);
+		$shapes = [
+			['pattern' => '/^(?:show|get|check|list|who\s+is|current\s+calls|help)\b/i', 'confidence' => 0.90, 'risk' => self::RISK_READ, 'reason' => 'read command shape'],
+			['pattern' => '/^(?:health|diagnose|troubleshoot)\b/i', 'confidence' => 0.88, 'risk' => self::RISK_READ, 'reason' => 'diagnostic command shape'],
+			['pattern' => '/^(?:enable|disable|set|clear|forward|configure)\b/i', 'confidence' => 0.90, 'risk' => self::RISK_STATE, 'reason' => 'state command shape'],
+			['pattern' => '/^(?:create|add|new|rename|update)\b/i', 'confidence' => 0.89, 'risk' => self::RISK_WRITE, 'reason' => 'write command shape'],
+			['pattern' => '/^(?:delete|remove|drop|decommission|retire)\b/i', 'confidence' => 0.50, 'risk' => self::RISK_UNKNOWN, 'reason' => 'destructive command shape'],
+		];
+		foreach ($shapes as $shape) {
+			if (preg_match($shape['pattern'], $work)) {
+				return $shape;
+			}
 		}
 		return null;
 	}

--- a/Tools/Interpret.php
+++ b/Tools/Interpret.php
@@ -94,7 +94,11 @@ class Interpret {
 		// 2a. Strip rude/urgent/emotional phrasing so we can recover the real command.
 		$work = self::expandTonePhrases($work);
 
-		// 2b. Normalise common spellings before intent rewrites.
+		// 2b. Strip trailing urgency/tone markers that otherwise get captured as
+		// names or labels by strict parser patterns.
+		$work = self::stripTrailingTone($work);
+
+		// 2c. Normalise common spellings before intent rewrites.
 		$spellings = [
 			'/\be-mail\b/i'      => 'email',
 			'/\bcall\s*forward\b/i' => 'call forward',
@@ -195,6 +199,22 @@ class Interpret {
 			return 'help';
 		}
 
+		return $work;
+	}
+
+	/**
+	 * Remove end-of-message urgency/tone phrases. Anchoring this at the end
+	 * avoids stripping ordinary words from entity names and search text.
+	 */
+	private static function stripTrailingTone($msg) {
+		$work = $msg;
+		$patterns = [
+			'/\s+(?:quickly|asap|ASAP|right\s+away|straight\s+away|immediately|now|today)\s*$/',
+			'/\s+(?:when\s+you\s+can|if\s+you\s+can|for\s+me)\s*$/',
+		];
+		foreach ($patterns as $pattern) {
+			$work = preg_replace($pattern, '', $work);
+		}
 		return $work;
 	}
 

--- a/Tools/Interpret.php
+++ b/Tools/Interpret.php
@@ -1,0 +1,244 @@
+<?php
+namespace FreePBX\modules\Frogman;
+
+/**
+ * Interpret — natural-language expansion layer for ChatParser.
+ *
+ * Sits between ChatParser's strict regex waterfall and its fuzzy matcher.
+ * Takes phrasing that wouldn't match strict patterns and rewrites it into
+ * phrasing that will, so the same tool catalog handles a wider vocabulary
+ * without bloating the parser itself.
+ *
+ * Pure text-in, text-out. No database, no session state, no schema changes.
+ *
+ * Local mode only in v1. The mode constant exists so future versions can
+ * route through a different backend without touching the call site in
+ * ChatParser.
+ *
+ * Disabled cleanly by setting the kvstore key 'frogman_interpret_mode'
+ * to 'off'.
+ *
+ * Parser helper only: this is not an AbstractTool and must not be
+ * auto-registered as a callable Frogman tool.
+ */
+class Interpret {
+
+	const MODE_OFF = 'off';
+	const MODE_LOCAL = 'local';
+	// Reserved for future use: MODE_REMOTE
+
+	/**
+	 * Entry point. ChatParser calls this when strict patterns have all missed.
+	 *
+	 * Returns one of:
+	 *   - string: a normalised version of the input. ChatParser should re-parse it.
+	 *   - null:   couldn't help. ChatParser falls through to fuzzy matching.
+	 */
+	public static function expand($msg) {
+		$mode = self::getMode();
+		if ($mode === self::MODE_OFF) {
+			return null;
+		}
+		if ($mode === self::MODE_LOCAL) {
+			return self::expandLocal($msg);
+		}
+		return null;
+	}
+
+	/**
+	 * Read the interpret mode from Frogman's FreePBX module config store.
+	 * Defaults to 'local'.
+	 * Admins can disable by setting it to 'off'.
+	 */
+	private static function getMode() {
+		try {
+			$val = \FreePBX::Frogman()->getConfig('frogman_interpret_mode');
+			if ($val === self::MODE_OFF || $val === self::MODE_LOCAL) {
+				return $val;
+			}
+		} catch (\Throwable $e) {
+			// Module config unavailable — fail safe to local.
+		}
+		return self::MODE_LOCAL;
+	}
+
+	/**
+	 * Local expansion. Strips filler, normalises phrasal verbs, and maps
+	 * anchored state-of-the-user phrases to PBX actions.
+	 *
+	 * Each transformation is deliberately anchored so it only fires when
+	 * we're confident it's an instruction, not a casual mention.
+	 */
+	private static function expandLocal($msg) {
+		$original = $msg;
+		$work = $msg;
+
+		// 1. Strip politeness and filler from the START of the message only.
+		//    Anchored so "show me just the failed calls" doesn't lose "just".
+		$leading = [
+			'/^\s*(please|pls|plz)\s+/i',
+			'/^\s*(could\s+you|can\s+you|would\s+you)\s+/i',
+			'/^\s*(i\s+need\s+to|i\s+want\s+to|i\s+would\s+like\s+to|i\'?d\s+like\s+to)\s+/i',
+			'/^\s*just\s+/i',
+		];
+		$work = preg_replace($leading, '', $work);
+
+		// 2. Strip mid-sentence politeness or tone markers that are always safe to drop.
+		$inline = [
+			'/\b(please|pls|plz)\b/i',
+			'/\b(for\s+me|if\s+you\s+can)\b/i',
+		];
+		$work = preg_replace($inline, '', $work);
+
+		// 2a. Strip rude/urgent/emotional phrasing so we can recover the real command.
+		$work = self::expandTonePhrases($work);
+
+		// 2b. Normalise common spellings before intent rewrites.
+		$spellings = [
+			'/\be-mail\b/i'      => 'email',
+			'/\bcall\s*forward\b/i' => 'call forward',
+			'/\bfollow\s+me\b/i' => 'followme',
+		];
+		foreach ($spellings as $pattern => $replacement) {
+			$work = preg_replace($pattern, $replacement, $work);
+		}
+
+		// 3. Phrasal verbs → single-word equivalents the strict patterns know.
+		//    Safe global replacements — these phrases don't have other meanings.
+		$phrasals = [
+			'/\b(have\s+a\s+look\s+at|take\s+a\s+look\s+at|look\s+at)\b/i' => 'show',
+			'/\b(get\s+me|pull\s+up|bring\s+up|find\s+me)\b/i'             => 'show',
+			'/\b(sort\s+out|deal\s+with|take\s+care\s+of)\b/i'             => 'fix',
+			'/\b(spin\s+up|stand\s+up|provision)\b/i'                       => 'create',
+			'/\b(decommission|retire)\b/i'                                  => 'delete',
+			'/\b(turn\s+on|switch\s+on)\b/i'                                => 'enable',
+			'/\b(turn\s+off|switch\s+off|shut\s+down|shut\s+off)\b/i'       => 'disable',
+			'/\b(reboot|bounce|cycle)\b/i'                                  => 'restart',
+		];
+		foreach ($phrasals as $pattern => $replacement) {
+			$work = preg_replace($pattern, $replacement, $work);
+		}
+
+		// 3a. Viewer phrasing that maps cleanly to existing strict anchors.
+		$viewPhrases = [
+			'/^\s*(show|get|check)\s+me\s+/i' => '$1 ',
+			'/^\s*(what\'?s|what\s+is)\s+(?:the\s+)?(ext|extension)\s+(\d{3,6})\s*$/i' => 'show extension $3',
+			'/^\s*(ext|extension)\s+(\d{3,6})\s*$/i' => 'show extension $2',
+			'/^\s*(who\'?s|who\s+is)\s+on\s+(?:the\s+)?phone\s*$/i' => 'who is on the phone',
+			'/^\s*(current|live)\s+call\s+activity\s*$/i' => 'current calls',
+		];
+		foreach ($viewPhrases as $pattern => $replacement) {
+			$work = preg_replace($pattern, $replacement, $work);
+		}
+
+		// 4. State-of-the-user phrases -> PBX actions.
+		//    Anchored to "<extension> is <state>" so bare "sick" or "left"
+		//    in unrelated phrases doesn't fire.
+		$work = self::expandStatePhrases($work);
+
+		// 4a. Remove conversational punctuation without damaging values like
+		// emails, IPs, phone numbers, or channel names.
+		$work = self::stripPunctuationNoise($work);
+
+		// 5. Collapse whitespace left behind by stripping.
+		$work = preg_replace('/\s+/', ' ', trim($work));
+
+		// 5a. Trim trailing punctuation and whitespace.
+		$work = trim($work);
+
+		// Only return if we changed something meaningful.
+		if ($work !== '' && $work !== $original) {
+			return $work;
+		}
+		return null;
+	}
+
+	/**
+	 * Tone-aware normalization. Removes emotional fill, blunt urgency, and
+	 * abusive language that would otherwise block a valid rewrite.
+	 */
+	private static function expandTonePhrases($msg) {
+		$work = $msg;
+
+		// Leading rude/urgent preambles before a command.
+		$leading = [
+			'/^\s*(?:just\s+)?do\s+what\s+(?:I|you)\s+(?:asked|said)(?:[.!?]*\s*)(?:and\s+|then\s+)?/i',
+			'/^\s*(?:just\s+)?I\s+told\s+you(?:\s+to)?(?:[.!?]*\s*)(?:and\s+|then\s+)?/i',
+			'/^\s*(?:just\s+)?you\s+better(?:[.!?]*\s*)(?:and\s+|then\s+)?/i',
+			'/^\s*(?:just\s+)?you\s+need\s+to(?:[.!?]*\s*)(?:and\s+|then\s+)?/i',
+			'/^\s*(?:do\s+it\s+now|do\s+it|now|right\s+now)(?:[.!?]*\s*)(?:and\s+|then\s+)?/i',
+			'/^\s*(?:listen|look|seriously|honestly)(?:[.!?]*\s*)(?:and\s+|then\s+)?/i',
+			'/^\s*(why\s+(?:won\'?t|can\'?t)\s+you\s+just|why\s+(?:won\'?t|can\'?t)\s+you)(?:\s+)?/i',
+		];
+		$work = preg_replace($leading, '', $work);
+
+		// Remove abusive words that are not essential to intent. Benign words
+		// like "just", "now", and "please" are left alone mid-sentence because
+		// they can be meaningful in entity names or search text.
+		$inlines = [
+			'/\b(fucking|damn|bloody|goddamn|shit|hell|bastard|son\s+of\s+a\s+bitch)\b/i',
+		];
+		foreach ($inlines as $pattern) {
+			$work = preg_replace($pattern, '', $work);
+		}
+
+		$work = preg_replace('/\s+/', ' ', trim($work));
+
+		// Remove punctuation left over from tone stripping.
+		$work = self::stripPunctuationNoise($work);
+		$work = preg_replace('/\s+/', ' ', trim($work));
+
+		// If the entire message is an emotional plea rather than a command,
+		// turn it into a help query.
+		if (preg_match('/^(?:I(?:\'m|\s+am)\s+(?:stuck|lost|overwhelmed|unsure|blocked|frozen)|I\s+can(?:\'t|not)\s+do\s+this|I\s+need\s+help|help\s+me|this\s+is\s+too\s+much|I\s+can\'t\s+handle\s+this)$/i', $work)) {
+			return 'help';
+		}
+
+		return $work;
+	}
+
+	/**
+	 * State phrases need extension-number anchoring to avoid firing on
+	 * unrelated uses of the words. Rewrites must land on strict ChatParser
+	 * anchors because the second pass runs with fuzzy matching disabled.
+	 * Bare "the call left the queue" → unchanged.
+	 */
+	private static function expandStatePhrases($msg) {
+		$work = $msg;
+
+		// "<ext> is sick/off/out/away (today)" -> "enable dnd on <ext>"
+		$work = preg_replace(
+			'/\b(\d{3,6})\s+(?:is\s+)?(?:called\s+in\s+)?(sick|off|out|away|unavailable)(?:\s+today)?\b/i',
+			'enable dnd on $1',
+			$work
+		);
+
+		// "<ext> is back/available" -> "disable dnd on <ext>"
+		$work = preg_replace(
+			'/\b(\d{3,6})\s+is\s+(back|available|in\s+today|back\s+in|back\s+at\s+work)\b/i',
+			'disable dnd on $1',
+			$work
+		);
+
+		// "<ext> is working from home" / "wfh" -> "set followme <ext>"
+		// This hits ChatParser's existing Follow Me wizard with ext pre-filled.
+		$work = preg_replace(
+			'/\b(\d{3,6})\s+is\s+(working\s+from\s+home|wfh|home\s+today|remote\s+today|working\s+remotely|remote)\b/i',
+			'set followme $1',
+			$work
+		);
+
+		return $work;
+	}
+
+	/**
+	 * Strip conversational punctuation while preserving punctuation that
+	 * belongs inside values such as email addresses, IPs, phone numbers,
+	 * hostnames, and Asterisk channel names.
+	 */
+	private static function stripPunctuationNoise($msg) {
+		$work = preg_replace('/[!?]+(?=\s|$)/', ' ', $msg);
+		$work = preg_replace('/[.,]+(?=\s|$)/', ' ', $work);
+		return $work;
+	}
+}

--- a/Tools/Interpret.php
+++ b/Tools/Interpret.php
@@ -185,9 +185,15 @@ class Interpret {
 		// 2. Vocabulary normalisation. These make user wording look like
 		// phrases the strict parser already understands.
 		self::applyRuleGroup($work, self::spellingRules(), $confidence, $risk, $reasons);
-		self::applyRuleGroup($work, self::phrasalVerbRules(), $confidence, $risk, $reasons);
+        self::applyRuleGroup($work, self::phrasalVerbRules(), $confidence, $risk, $reasons);
 
-		// 3. Intent rewrites. These are stricter, usually anchored, and should
+        $before = $work;
+        $work = preg_replace('/^\s*(delete|remove|disable|drop)\s+(\d{3,6})\s*$/i', '$1 extension $2', $work);
+        if ($work !== $before) {
+	    self::markRewrite($confidence, $risk, $reasons, 0.96, self::RISK_WRITE, 'numeric extension delete shorthand');
+        }
+
+        // 3. Intent rewrites. These are stricter, usually anchored, and should
 		// land directly on known ChatParser command shapes.
 		self::applyRuleGroup($work, self::viewerPhraseRules(), $confidence, $risk, $reasons);
 		$before = $work;
@@ -299,7 +305,7 @@ class Interpret {
 			['pattern' => '/^(?:health|diagnose|troubleshoot)\b/i', 'confidence' => 0.88, 'risk' => self::RISK_READ, 'reason' => 'diagnostic command shape'],
 			['pattern' => '/^(?:enable|disable|set|clear|forward|configure)\b/i', 'confidence' => 0.90, 'risk' => self::RISK_STATE, 'reason' => 'state command shape'],
 			['pattern' => '/^(?:create|add|new|rename|update)\b/i', 'confidence' => 0.89, 'risk' => self::RISK_WRITE, 'reason' => 'write command shape'],
-			['pattern' => '/^(?:delete|remove|drop|decommission|retire)\b/i', 'confidence' => 0.50, 'risk' => self::RISK_UNKNOWN, 'reason' => 'destructive command shape'],
+			['pattern' => '/^(?:delete|remove|drop|disable)\s+(?:ext|extension)\s+\d{3,6}$/i', 'confidence' => 0.96, 'risk' => self::RISK_WRITE, 'reason' => 'known extension removal command shape'],
 		];
 		foreach ($shapes as $shape) {
 			if (preg_match($shape['pattern'], $work)) {

--- a/Tools/Interpret.php
+++ b/Tools/Interpret.php
@@ -76,7 +76,7 @@ class Interpret {
 		$thresholds = [
 			self::RISK_READ => 0.78,
 			self::RISK_WRITE => 0.88,
-			self::RISK_STATE => 0.90,
+			self::RISK_STATE => 0.91,
 			self::RISK_UNKNOWN => 0.95,
 		];
 		return $confidence >= ($thresholds[$risk] ?? $thresholds[self::RISK_UNKNOWN]);
@@ -275,12 +275,15 @@ class Interpret {
 	private static function spellingRules() {
 		return [
 			['pattern' => '/\be-mail\b/i', 'replacement' => 'email', 'confidence' => 0.86, 'reason' => 'spelling normalisation'],
-			['pattern' => '/\bcall\s*forward\b/i', 'replacement' => 'call forward', 'confidence' => 0.86, 'reason' => 'spelling normalisation'],
+			['pattern' => '/\bcall\s*forward\b/i', 'replacement' => 'call forward', 'confidence' => 0.86, 'reason' => 'whitespace-tolerant call forward normalisation'],
 			['pattern' => '/\bfollow\s+me\b/i', 'replacement' => 'followme', 'confidence' => 0.86, 'reason' => 'spelling normalisation'],
 		];
 	}
 
 	private static function phrasalVerbRules() {
+		// RISK_UNKNOWN is intentional. Phrasal rewrites alone aren't sufficient
+		// evidence to act on; they need a corroborating command-shape score
+		// from scoreCommandShape() to clear shouldRun()'s threshold.
 		return [
 			['pattern' => '/\b(have\s+a\s+look\s+at|take\s+a\s+look\s+at|look\s+at)\b/i', 'replacement' => 'show', 'confidence' => 0.72, 'risk' => self::RISK_UNKNOWN, 'reason' => 'phrasal verb'],
 			['pattern' => '/\b(get\s+me|pull\s+up|bring\s+up|find\s+me)\b/i', 'replacement' => 'show', 'confidence' => 0.72, 'risk' => self::RISK_UNKNOWN, 'reason' => 'phrasal verb'],
@@ -375,7 +378,7 @@ class Interpret {
 		$patterns = [
 			'/^\s*(?:you(?:\'re|re| are)?\s+)?' . $insults . '[.!?,-]*\s*/i',
 			'/^\s*(?:you(?:\'re|re| are)\s+)?(?:bloody|fucking|damn|goddamn)\s+' . $insults . '[.!?,-]*\s*/i',
-			'/[\s,]+(?:you(?:\'re|re| are)?\s+)?' . $insults . '\s*$/',
+			'/[\s,]+(?:you(?:\'re|re| are)?\s+)?' . $insults . '\s*$/i',
 		];
 		foreach ($patterns as $pattern) {
 			$work = preg_replace($pattern, ' ', $work);

--- a/Tools/Interpret.php
+++ b/Tools/Interpret.php
@@ -47,6 +47,36 @@ class Interpret {
 	}
 
 	/**
+	 * True when the user is explicitly saying the pending action is wrong.
+	 * ChatParser calls this before wizard/confirmation text is consumed as input.
+	 */
+	public static function isCorrectionCancel($msg) {
+		$work = trim($msg);
+		$work = self::stripPunctuationNoise($work);
+		$work = preg_replace('/\s+/', ' ', trim($work));
+
+		$patterns = [
+			'/^(?:no\s*){2,}$/i',
+			'/^(?:no+\s+)+no+$/i',
+			'/^(?:no\s+thanks|no\s+thank\s+you|not\s+now)$/i',
+			'/^(?:no\s+)?(?:you|u)\s+mis+understood$/i',
+			'/^(?:that(?:\'s|s| is)\s+)?not\s+what\s+i\s+mea?nt$/i',
+			'/^(?:i\s+didn\'?t|i\s+didnt)\s+mea?nt?\s+(?:that|this)$/i',
+			'/^(?:not\s+what\s+i\s+asked|not\s+what\s+i\s+wanted)$/i',
+			'/^(?:that(?:\'s|s| is)\s+)?(?:the\s+)?wrong\s+(?:thing|command|one)$/i',
+			'/^stop\s+(?:that(?:\'s|s| is)\s+)?wrong$/i',
+			'/^don\'?t\s+do\s+that$/i',
+			'/^cancel\s+that$/i',
+		];
+		foreach ($patterns as $pattern) {
+			if (preg_match($pattern, $work)) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	/**
 	 * Read the interpret mode from Frogman's FreePBX module config store.
 	 * Defaults to 'local'.
 	 * Admins can disable by setting it to 'off'.

--- a/Tools/Interpret.php
+++ b/Tools/Interpret.php
@@ -97,7 +97,9 @@ class Interpret {
 			'/^(?:no\s+thanks|no\s+thank\s+you|not\s+now)$/i',
 			'/^(?:no\s+)?(?:you|u)\s+mis+understood$/i',
 			'/^(?:that(?:\'s|s| is)\s+)?not\s+what\s+i\s+mea?nt$/i',
-			'/^(?:i\s+didn\'?t|i\s+didnt)\s+mea?nt?\s+(?:that|this)$/i',
+			'/^(?:i\s+didn\'?t|i\s+didnt|i\s+did\s+not)\s+mea?nt?\s+(?:that|this)$/i',
+			'/^(?:i\s+didn\'?t|i\s+didnt|i\s+did\s+not)\s+say\s+(?:that|this)(?:\s+(?:idiot|stupid|damn|dammit|ffs))?$/i',
+			'/^(?:i\s+didn\'?t|i\s+didnt|i\s+did\s+not)\s+ask\s+for\s+(?:that|this)(?:\s+(?:idiot|stupid|damn|dammit|ffs))?$/i',
 			'/^(?:not\s+what\s+i\s+asked|not\s+what\s+i\s+wanted)$/i',
 			'/^(?:that(?:\'s|s| is)\s+)?(?:the\s+)?wrong\s+(?:thing|command|one)$/i',
 			'/^stop\s+(?:that(?:\'s|s| is)\s+)?wrong$/i',
@@ -157,125 +159,47 @@ class Interpret {
 		$risk = self::RISK_READ;
 		$reasons = [];
 
-		// 1. Strip politeness and filler from the START of the message only.
-		//    Anchored so "show me just the failed calls" doesn't lose "just".
-		$leading = [
-			'/^\s*(please|pls|plz)\s+/i',
-			'/^\s*(could\s+you|can\s+you|would\s+you)\s+/i',
-			'/^\s*(i\s+need\s+to|i\s+want\s+to|i\s+would\s+like\s+to|i\'?d\s+like\s+to)\s+/i',
-			'/^\s*just\s+/i',
-		];
-		$before = $work;
-		$work = preg_replace($leading, '', $work);
-		if ($work !== $before) {
-			$confidence = max($confidence, 0.82);
-			$reasons[] = 'leading request wrapper';
-		}
+		// 1. Conversation/tone cleanup. These remove wrappers around intent
+		// without changing the PBX object/action being requested.
+		self::applyRuleGroup($work, self::requestWrapperRules(), $confidence, $risk, $reasons);
+		self::applyRuleGroup($work, self::inlinePolitenessRules(), $confidence, $risk, $reasons);
 
-		// 2. Strip mid-sentence politeness or tone markers that are always safe to drop.
-		$inline = [
-			'/\b(please|pls|plz)\b/i',
-			'/\b(for\s+me|if\s+you\s+can)\b/i',
-		];
-		$before = $work;
-		$work = preg_replace($inline, '', $work);
-		if ($work !== $before) {
-			$confidence = max($confidence, 0.80);
-			$reasons[] = 'inline politeness';
-		}
-
-		// 2a. Strip rude/urgent/emotional phrasing so we can recover the real command.
 		$before = $work;
 		$work = self::expandTonePhrases($work);
 		if ($work !== $before) {
-			$confidence = max($confidence, $work === 'help' ? 0.93 : 0.78);
-			$risk = $work === 'help' ? self::RISK_READ : $risk;
-			$reasons[] = 'tone wrapper';
+			self::markRewrite($confidence, $risk, $reasons, $work === 'help' ? 0.93 : 0.78, $work === 'help' ? self::RISK_READ : null, 'tone wrapper');
 		}
 
-		// 2b. Strip trailing urgency/tone markers that otherwise get captured as
-		// names or labels by strict parser patterns.
+		$before = $work;
+		$work = self::stripAssistantAbuse($work);
+		if ($work !== $before) {
+			self::markRewrite($confidence, $risk, $reasons, 0.78, null, 'assistant-directed abuse');
+		}
+
 		$before = $work;
 		$work = self::stripTrailingTone($work);
 		if ($work !== $before) {
-			$confidence = max($confidence, 0.84);
-			$reasons[] = 'trailing urgency';
+			self::markRewrite($confidence, $risk, $reasons, 0.84, null, 'trailing urgency');
 		}
 
-		// 2c. Normalise common spellings before intent rewrites.
-		$spellings = [
-			'/\be-mail\b/i'      => 'email',
-			'/\bcall\s*forward\b/i' => 'call forward',
-			'/\bfollow\s+me\b/i' => 'followme',
-		];
-		foreach ($spellings as $pattern => $replacement) {
-			$before = $work;
-			$work = preg_replace($pattern, $replacement, $work);
-			if ($work !== $before) {
-				$confidence = max($confidence, 0.86);
-				$reasons[] = 'spelling normalisation';
-			}
-		}
+		// 2. Vocabulary normalisation. These make user wording look like
+		// phrases the strict parser already understands.
+		self::applyRuleGroup($work, self::spellingRules(), $confidence, $risk, $reasons);
+		self::applyRuleGroup($work, self::phrasalVerbRules(), $confidence, $risk, $reasons);
 
-		// 3. Phrasal verbs → single-word equivalents the strict patterns know.
-		//    Safe global replacements — these phrases don't have other meanings.
-		$phrasals = [
-			'/\b(have\s+a\s+look\s+at|take\s+a\s+look\s+at|look\s+at)\b/i' => 'show',
-			'/\b(get\s+me|pull\s+up|bring\s+up|find\s+me)\b/i'             => 'show',
-			'/\b(sort\s+out|deal\s+with|take\s+care\s+of)\b/i'             => 'fix',
-			'/\b(spin\s+up|stand\s+up|provision)\b/i'                       => 'create',
-			'/\b(decommission|retire)\b/i'                                  => 'delete',
-			'/\b(turn\s+on|switch\s+on)\b/i'                                => 'enable',
-			'/\b(turn\s+off|switch\s+off|shut\s+down|shut\s+off)\b/i'       => 'disable',
-			'/\b(reboot|bounce|cycle)\b/i'                                  => 'restart',
-		];
-		foreach ($phrasals as $pattern => $replacement) {
-			$before = $work;
-			$work = preg_replace($pattern, $replacement, $work);
-			if ($work !== $before) {
-				$confidence = max($confidence, 0.72);
-				$risk = self::RISK_UNKNOWN;
-				$reasons[] = 'phrasal verb';
-			}
-		}
-
-		// 3a. Viewer phrasing that maps cleanly to existing strict anchors.
-		$viewPhrases = [
-			'/^\s*(show|get|check)\s+me\s+/i' => '$1 ',
-			'/^\s*(what\'?s|what\s+is)\s+(?:the\s+)?(ext|extension)\s+(\d{3,6})\s*$/i' => 'show extension $3',
-			'/^\s*(ext|extension)\s+(\d{3,6})\s*$/i' => 'show extension $2',
-			'/^\s*(who\'?s|who\s+is)\s+on\s+(?:the\s+)?phone\s*$/i' => 'who is on the phone',
-			'/^\s*(current|live)\s+call\s+activity\s*$/i' => 'current calls',
-		];
-		foreach ($viewPhrases as $pattern => $replacement) {
-			$before = $work;
-			$work = preg_replace($pattern, $replacement, $work);
-			if ($work !== $before) {
-				$confidence = max($confidence, 0.91);
-				$risk = self::RISK_READ;
-				$reasons[] = 'viewer phrase';
-			}
-		}
-
-		// 4. State-of-the-user phrases -> PBX actions.
-		//    Anchored to "<extension> is <state>" so bare "sick" or "left"
-		//    in unrelated phrases doesn't fire.
+		// 3. Intent rewrites. These are stricter, usually anchored, and should
+		// land directly on known ChatParser command shapes.
+		self::applyRuleGroup($work, self::viewerPhraseRules(), $confidence, $risk, $reasons);
 		$before = $work;
 		$work = self::expandStatePhrases($work);
 		if ($work !== $before) {
-			$confidence = max($confidence, 0.94);
-			$risk = self::RISK_STATE;
-			$reasons[] = 'extension state phrase';
+			self::markRewrite($confidence, $risk, $reasons, 0.94, self::RISK_STATE, 'extension state phrase');
 		}
 
-		// 4a. Remove conversational punctuation without damaging values like
-		// emails, IPs, phone numbers, or channel names.
+		// 4. Final cleanup preserves structured values, then command-shape
+		// scoring decides whether the rewrite is safe enough to run.
 		$work = self::stripPunctuationNoise($work);
-
-		// 5. Collapse whitespace left behind by stripping.
 		$work = preg_replace('/\s+/', ' ', trim($work));
-
-		// 5a. Trim trailing punctuation and whitespace.
 		$work = trim($work);
 
 		// Only return if we changed something meaningful.
@@ -294,6 +218,78 @@ class Interpret {
 			];
 		}
 		return null;
+	}
+
+	private static function applyRuleGroup(&$work, $rules, &$confidence, &$risk, &$reasons) {
+		foreach ($rules as $rule) {
+			$before = $work;
+			$work = preg_replace($rule['pattern'], $rule['replacement'], $work);
+			if ($work !== $before) {
+				self::markRewrite(
+					$confidence,
+					$risk,
+					$reasons,
+					$rule['confidence'],
+					$rule['risk'] ?? null,
+					$rule['reason']
+				);
+			}
+		}
+	}
+
+	private static function markRewrite(&$confidence, &$risk, &$reasons, $newConfidence, $newRisk, $reason) {
+		$confidence = max($confidence, $newConfidence);
+		if ($newRisk !== null) {
+			$risk = $newRisk;
+		}
+		$reasons[] = $reason;
+	}
+
+	private static function requestWrapperRules() {
+		return [
+			['pattern' => '/^\s*(please|pls|plz)\s+/i', 'replacement' => '', 'confidence' => 0.82, 'reason' => 'leading request wrapper'],
+			['pattern' => '/^\s*(could\s+you|can\s+you|would\s+you)\s+/i', 'replacement' => '', 'confidence' => 0.82, 'reason' => 'leading request wrapper'],
+			['pattern' => '/^\s*(i\s+need\s+to|i\s+want\s+to|i\s+would\s+like\s+to|i\'?d\s+like\s+to)\s+/i', 'replacement' => '', 'confidence' => 0.82, 'reason' => 'leading request wrapper'],
+			['pattern' => '/^\s*just\s+/i', 'replacement' => '', 'confidence' => 0.82, 'reason' => 'leading request wrapper'],
+		];
+	}
+
+	private static function inlinePolitenessRules() {
+		return [
+			['pattern' => '/\b(please|pls|plz)\b/i', 'replacement' => '', 'confidence' => 0.80, 'reason' => 'inline politeness'],
+			['pattern' => '/\b(for\s+me|if\s+you\s+can)\b/i', 'replacement' => '', 'confidence' => 0.80, 'reason' => 'inline politeness'],
+		];
+	}
+
+	private static function spellingRules() {
+		return [
+			['pattern' => '/\be-mail\b/i', 'replacement' => 'email', 'confidence' => 0.86, 'reason' => 'spelling normalisation'],
+			['pattern' => '/\bcall\s*forward\b/i', 'replacement' => 'call forward', 'confidence' => 0.86, 'reason' => 'spelling normalisation'],
+			['pattern' => '/\bfollow\s+me\b/i', 'replacement' => 'followme', 'confidence' => 0.86, 'reason' => 'spelling normalisation'],
+		];
+	}
+
+	private static function phrasalVerbRules() {
+		return [
+			['pattern' => '/\b(have\s+a\s+look\s+at|take\s+a\s+look\s+at|look\s+at)\b/i', 'replacement' => 'show', 'confidence' => 0.72, 'risk' => self::RISK_UNKNOWN, 'reason' => 'phrasal verb'],
+			['pattern' => '/\b(get\s+me|pull\s+up|bring\s+up|find\s+me)\b/i', 'replacement' => 'show', 'confidence' => 0.72, 'risk' => self::RISK_UNKNOWN, 'reason' => 'phrasal verb'],
+			['pattern' => '/\b(sort\s+out|deal\s+with|take\s+care\s+of)\b/i', 'replacement' => 'fix', 'confidence' => 0.72, 'risk' => self::RISK_UNKNOWN, 'reason' => 'phrasal verb'],
+			['pattern' => '/\b(spin\s+up|stand\s+up|provision)\b/i', 'replacement' => 'create', 'confidence' => 0.72, 'risk' => self::RISK_UNKNOWN, 'reason' => 'phrasal verb'],
+			['pattern' => '/\b(decommission|retire)\b/i', 'replacement' => 'delete', 'confidence' => 0.72, 'risk' => self::RISK_UNKNOWN, 'reason' => 'phrasal verb'],
+			['pattern' => '/\b(turn\s+on|switch\s+on)\b/i', 'replacement' => 'enable', 'confidence' => 0.72, 'risk' => self::RISK_UNKNOWN, 'reason' => 'phrasal verb'],
+			['pattern' => '/\b(turn\s+off|switch\s+off|shut\s+down|shut\s+off)\b/i', 'replacement' => 'disable', 'confidence' => 0.72, 'risk' => self::RISK_UNKNOWN, 'reason' => 'phrasal verb'],
+			['pattern' => '/\b(reboot|bounce|cycle)\b/i', 'replacement' => 'restart', 'confidence' => 0.72, 'risk' => self::RISK_UNKNOWN, 'reason' => 'phrasal verb'],
+		];
+	}
+
+	private static function viewerPhraseRules() {
+		return [
+			['pattern' => '/^\s*(show|get|check)\s+me\s+/i', 'replacement' => '$1 ', 'confidence' => 0.91, 'risk' => self::RISK_READ, 'reason' => 'viewer phrase'],
+			['pattern' => '/^\s*(what\'?s|what\s+is)\s+(?:the\s+)?(ext|extension)\s+(\d{3,6})\s*$/i', 'replacement' => 'show extension $3', 'confidence' => 0.91, 'risk' => self::RISK_READ, 'reason' => 'viewer phrase'],
+			['pattern' => '/^\s*(ext|extension)\s+(\d{3,6})\s*$/i', 'replacement' => 'show extension $2', 'confidence' => 0.91, 'risk' => self::RISK_READ, 'reason' => 'viewer phrase'],
+			['pattern' => '/^\s*(who\'?s|who\s+is)\s+on\s+(?:the\s+)?phone\s*$/i', 'replacement' => 'who is on the phone', 'confidence' => 0.91, 'risk' => self::RISK_READ, 'reason' => 'viewer phrase'],
+			['pattern' => '/^\s*(current|live)\s+call\s+activity\s*$/i', 'replacement' => 'current calls', 'confidence' => 0.91, 'risk' => self::RISK_READ, 'reason' => 'viewer phrase'],
+		];
 	}
 
 	private static function scoreCommandShape($msg) {
@@ -336,7 +332,7 @@ class Interpret {
 		// like "just", "now", and "please" are left alone mid-sentence because
 		// they can be meaningful in entity names or search text.
 		$inlines = [
-			'/\b(fucking|damn|bloody|goddamn|shit|hell|bastard|son\s+of\s+a\s+bitch)\b/i',
+			'/\b(fucking|damn|bloody|goddamn|shit|hell|bastard|son\s+of\s+a\s+bitch|bitch)\b/i',
 		];
 		foreach ($inlines as $pattern) {
 			$work = preg_replace($pattern, '', $work);
@@ -355,6 +351,24 @@ class Interpret {
 		}
 
 		return $work;
+	}
+
+	/**
+	 * Remove insults aimed at the assistant, not potentially meaningful
+	 * descriptors attached to PBX objects.
+	 */
+	private static function stripAssistantAbuse($msg) {
+		$work = $msg;
+		$insults = '(?:idiot|moron|twat|cunt|prick|wanker|dumbass|dumb\s+ass|clown|fool|shitbot|useless\s+(?:bot|machine|thing)|stupid\s+(?:bot|machine|thing))';
+		$patterns = [
+			'/^\s*(?:you(?:\'re|re| are)?\s+)?' . $insults . '[.!?,-]*\s*/i',
+			'/^\s*(?:you(?:\'re|re| are)\s+)?(?:bloody|fucking|damn|goddamn)\s+' . $insults . '[.!?,-]*\s*/i',
+			'/[\s,]+(?:you(?:\'re|re| are)?\s+)?' . $insults . '\s*$/',
+		];
+		foreach ($patterns as $pattern) {
+			$work = preg_replace($pattern, ' ', $work);
+		}
+		return preg_replace('/\s+/', ' ', trim($work));
 	}
 
 	/**

--- a/Tools/Interpret.php
+++ b/Tools/Interpret.php
@@ -154,10 +154,15 @@ class Interpret {
 	 */
 	private static function interpretLocal($msg) {
 		$original = $msg;
-		$work = $msg;
-		$confidence = 0.70;
-		$risk = self::RISK_READ;
-		$reasons = [];
+        $work = trim($msg);
+
+        if (preg_match('/^`(.+)`$/s', $work, $m)) {
+	    $work = trim($m[1]);
+        }
+
+        $confidence = 0.70;
+        $risk = self::RISK_READ;
+        $reasons = [];
 
 		// 1. Conversation/tone cleanup. These remove wrappers around intent
 		// without changing the PBX object/action being requested.


### PR DESCRIPTION
## What this is
 
`Tools/Interpret.php` is a deterministic, regex-driven layer that sits between the user and ChatParser's strict regex waterfall. It rewrites conversational, polite, urgent, abusive, or otherwise human phrasing into the canonical command forms ChatParser already understands.
 
It is not a tool. It is a parser helper, and it deliberately stays outside the AbstractTool auto-loader so it cannot be invoked as a tool.
 
There is no LLM, no database, no session state, and no schema change. Pure text-in, text-out.
 
## Why
 
Frogman is better framed as a CLI that accepts natural-language input than a free-form agent. Interpret keeps the parser strict and predictable while widening the vocabulary it accepts. Adding a new rule is a small, reviewable change in one file; the parser does not grow.
 
## Architecture
 
Two entry points:
 
- `expand($msg)` returns a normalised string or null. This is the compatibility surface ChatParser already uses.
- `interpret($msg)` returns structured intent: `text`, `confidence` (0.0–1.0), `risk` (read / write / state / unknown), `reason`. Available for richer integration if and when ChatParser wants to use it; not required.
`expand()` is a thin wrapper around `interpret()` plus `shouldRun()`. The change is additive. Existing call sites are unaffected.
 
### Risk-aware confidence model
 
Rewrites are gated by per-risk thresholds in `shouldRun()`:
 
- `read` 0.78
- `write` 0.88
- `state` 0.91
- `unknown` 0.95

A state-changing rewrite needs higher evidence than a read. The `unknown` ceiling means a rewrite that hasn't been corroborated by a recognised command shape will not auto-run. This keeps the parser conservative on phrasings the layer has only partially understood.
 
### Command-shape scoring
 
`scoreCommandShape()` looks at the final rewritten string and matches it against a small set of known command shapes (extension create/remove, read commands, diagnostics, state changes, generic writes). When a shape is recognised, the result's confidence is raised and risk is set accordingly. A rewrite that produces text the parser can act on gets the credit it deserves.
 
### Disable cleanly
 
Set kvstore key `frogman_interpret_mode` to `off` and Interpret short-circuits to null. The parser falls back to its existing behaviour. Default is `local`. A `remote` mode constant is reserved for future use; v1 ships local only.
 
## What it currently handles
 
### Conversation / tone cleanup
 
- Leading request wrappers ("please", "could you", "i would like to", "just")
- Inline politeness ("please", "for me")
- Tone wrappers ("listen", "look", "you better", "why won't you just")
- Assistant-directed abuse ("you idiot", "you bloody clown", trailing variants)
- Trailing urgency ("quickly", "asap", "right away", "now", "today", "when you can")
- Emotional pleas ("I'm stuck", "I need help", "help me") → `help`

### Vocabulary normalisation
 
- Spelling and whitespace tolerance ("e-mail" → "email", "callforward" → "call forward", "follow me" → "followme")
- Phrasal verbs ("have a look at" / "pull up" / "see" / "view" / "display" → "show"; "sort out" / "deal with" → "fix"; "turn off" / "switch off" / "shut down" → "disable"; "turn on" → "enable"; "reboot" / "bounce" → "restart"; "decommission" / "retire" → "delete"; "spin up" / "stand up" / "provision" → "create")
- Numeric extension shorthand ("delete 2001" → "delete extension 2001"). Anchored to known write verbs to avoid mangling unrelated digit strings.

### Intent rewrites
 
- Viewer phrases ("show me X" → "show X", "extension 1001" → "show extension 1001", "what is extension 1001" → "show extension 1001", "who is on the phone")
- Article stripping ("show the trunks" → "show trunks") — runs after phrasal verb normalisation so cases like "i would like to see the trunks" resolve cleanly
- Extension state phrases (anchored on a 3–6 digit extension number to prevent accidental firing):
  - `<ext> is sick / off / out / away (today)` → `enable dnd on <ext>`
  - `<ext> is back / available / in today` → `disable dnd on <ext>`
  - `<ext> is working from home / wfh / remote` → `set followme <ext>`
 
### Correction-cancel helper
 
`isCorrectionCancel($msg)` returns true for explicit user corrections ("no no", "that's not what I meant", "you misunderstood", "wrong command", "cancel that", "I didn't say that"). ChatParser can call this before consuming a yes/no response so a frustrated user can stop a pending action without it being read as confirmation. Not wired into ChatParser by this PR; the helper is available for use.
 
### Rephrase prompt
 
`rephrasePrompt($original, $expanded)` returns a friendly message when Interpret produced a change but the result still failed to clear `shouldRun()`. Tells the user what we tried to read it as. Avoids silent failures or accidental executions.
 
## Safety properties
 
- All rewrites are anchored. State phrases require a leading extension number. Phrasal verbs are tagged `RISK_UNKNOWN` so they cannot clear `shouldRun()` on their own; they need a corroborating command-shape score.
- Email addresses, IPs, phone numbers, hostnames, and channel names survive cleanup. `stripPunctuationNoise()` only strips conversational punctuation at word boundaries.
- `RISK_UNKNOWN` floor (0.95) means a partially understood rewrite never auto-runs.
- The `class_exists` guard prevents fatal errors on repeated includes inside FreePBX.
- The autoloader exclusion comment makes Frogman's tool scanner skip the file.
## Integration with v1.6.7 audit log
 
The audit-log changes Mike shipped in v1.6.7 (`chat_input` and `interpreted_as` columns plus secret redaction) are already populated correctly by this PR. Verified on the test box: chat-initiated calls show the original phrasing in `chat_input` and the rewritten canonical command in `interpreted_as`. Non-chat paths leave both NULL.
 
This provides a clear audit trail from user input to rewritten command to executed action.
 
## Test plan
 
Verified manually via `fwconsole frogman:chat` on a clean FreePBX 17 install with Frogman v1.6.7 plus this change.
 
### Should rewrite and execute
 
```
please show extension 2001
could you have a look at extension 2001
i would like to see the trunks
just show me the failed calls
turn off SIPStation
shut down trunk 5
switch on voicemail on 2001
2001 is sick
2001 is on holiday
2001 is working from home
2001 is back
you idiot show extension 2001
just bloody disable SIPStation
set callforward 2001 to 1002
delete 2001
```
 
### Should ask for rephrase (changed but didn't land on a known shape)
 
```
have a look at things
pull up the stuff
```
 
### Should cancel pending action
 
```
no no
that's not what I meant
wrong command
cancel that
you misunderstood
```
 
### Should pass through unchanged (regression check)
 
```
show extension 2001
list trunks
list extensions
diagnose extension 2001
help
```
 
All five regression phrases continue to hit ChatParser's strict patterns directly. Interpret made no changes.
 
## Scope note
 
This extends slightly beyond the v1 shape that was originally intended (text-in / text-out only). The additions are:
 
- Confidence and risk are now exposed via `interpret()`. `expand()` keeps the v1 surface.
- Command-shape scoring boosts confidence on recognised forms.
- Correction-cancel and rephrase-prompt helpers.
Happy to row back to a v1-shape (drop `interpret()` and the helpers, ship only `expand()`) if preferred. The richer interface seemed worth proposing because it gives the audit log something to record beyond "raw vs interpreted" and gives ChatParser a way to handle low-confidence cases without guessing.
 
## What's deliberately not in this PR
 
- Pronoun resolution ("him", "the same one"). Needs session state; better as a follow-up once we know what shape Mike wants for that.
- LLM-backed `remote` mode. The constant exists; v1 ships local only.
- Wider vocabulary. Easy to add; not landed here because each rule warrants its own review.
- Integration of `isCorrectionCancel()` into ChatParser's pending-input flow. The helper is available; the wiring is left to a future PR so this one stays focused.
## Also fixed
 
`Console/Chat.class.php` — removed the raw ANSI escape from the `frogman>` prompt that displayed as literal `\033[36m...\033[0m` characters in some terminals. Kept `readline()` and history; just dropped the colour wrapper.
 
## Files changed
 
- `Tools/Interpret.php` (new)
- `Tools/ChatParser.php` (one new branch in `parse()` to call `Interpret::expand()` before the fuzzy matcher)
- `Console/Chat.class.php` (require the new file + ANSI prompt fix above)