### PR TITLE
Queue edits reset every setting the caller didn't name

### DIFF
--- a/Tools/AddQueue.php
+++ b/Tools/AddQueue.php
@@ -110,52 +110,132 @@ class AddQueue extends AbstractTool {
 		return '';
 	}
 
+	// Every $_REQUEST key queues_add() reads, as
+	//   request key => [queues_get() key it round-trips from, literal default, tool param name]
+	// Authoritative source: queues/functions.inc/geters_seters.php queues_add().
+	// The queues_get() key is often spelled differently from the $_REQUEST key
+	// (announcefreq → announce-frequency), which is exactly why a naive merge
+	// silently drops fields.
+	private static $requestMap = [
+		'strategy'            => ['strategy',                    'ringall',  'strategy'],
+		'timeout'             => ['timeout',                     '15',       'timeout'],
+		'retry'               => ['retry',                       '5',        'retry'],
+		'wrapuptime'          => ['wrapuptime',                  '0',        'wrapuptime'],
+		'weight'              => ['weight',                      '0',        'weight'],
+		'maxlen'              => ['maxlen',                      '0',        'maxlen'],
+		'joinempty'           => ['joinempty',                   'yes',      'joinempty'],
+		'leavewhenempty'      => ['leavewhenempty',              'no',       'leavewhenempty'],
+		'announceposition'    => ['announce-position',           'no',       'announce_position'],
+		'announceholdtime'    => ['announce-holdtime',           'no',       'announce_holdtime'],
+		'announcefreq'        => ['announce-frequency',          '0',        'announce_frequency'],
+		'min-announce'        => ['min-announce-frequency',      '15',       'min_announce_frequency'],
+		'pannouncefreq'       => ['periodic-announce-frequency', '0',        'periodic_announce_frequency'],
+		'recording'           => ['recording',                   'dontcare', 'recording'],
+		'reportholdtime'      => ['reportholdtime',              'no',       'reportholdtime'],
+		'autopause'           => ['autopause',                   'no',       'autopause'],
+		'autopausedelay'      => ['autopausedelay',              '0',        'autopausedelay'],
+		'autopausebusy'       => ['autopausebusy',               'no',       'autopausebusy'],
+		'autopauseunavail'    => ['autopauseunavail',            'no',       'autopauseunavail'],
+		'servicelevel'        => ['servicelevel',                '60',       'servicelevel'],
+		'memberdelay'         => ['memberdelay',                 '0',        'memberdelay'],
+		'timeoutrestart'      => ['timeoutrestart',              'no',       'timeoutrestart'],
+		'timeoutpriority'     => ['timeoutpriority',             'app',      'timeoutpriority'],
+		'skip_joinannounce'   => ['skip_joinannounce',           '',         'skip_joinannounce'],
+		'answered_elsewhere'  => ['answered_elsewhere',          '0',        'answered_elsewhere'],
+		'penaltymemberslimit' => ['penaltymemberslimit',         '0',        'penaltymemberslimit'],
+		'rvolume'             => ['rvolume',                     '',         'rvolume'],
+		'rvol_mode'           => ['rvol_mode',                   '',         'rvol_mode'],
+		'rtone'               => ['rtone',                       '0',        'rtone'],
+	];
+
+	// queues_add() also reads these, but the create path deliberately leaves them
+	// unset so FreePBX/$amp_conf supplies the default. On the update path we set
+	// them ONLY when the queue already has a value, so an edit doesn't reset them.
+	private static $preserveOnly = [
+		'eventwhencalled'   => 'eventwhencalled',
+		'eventmemberstatus' => 'eventmemberstatus',
+		'announcemenu'      => 'announcemenu',
+		'callback'          => 'callback',
+	];
+
 	// Pre-populate $_REQUEST with the fields queues_add() reads directly.
 	// Returns the prior $_REQUEST so the caller can restore it after the call.
 	// Static so UpdateQueue + member tools can reuse without subclassing.
-	public static function applyRequest(array $params) {
+	//
+	// $current is queues_get() output on the UPDATE path and empty on create.
+	// Resolution order is: explicit param > current value > literal default. With
+	// $current empty every field collapses to the literal, so create behaviour is
+	// byte-for-byte what it was before this parameter existed.
+	public static function applyRequest(array $params, array $current = []) {
 		$prior = $_REQUEST;
 		$_REQUEST['action'] = $params['_action'] ?? 'add';
-		$_REQUEST['strategy'] = $params['strategy'] ?? 'ringall';
-		$_REQUEST['timeout'] = isset($params['timeout']) ? (string)(int)$params['timeout'] : '15';
-		$_REQUEST['retry'] = isset($params['retry']) ? (string)(int)$params['retry'] : '5';
-		$_REQUEST['wrapuptime'] = isset($params['wrapuptime']) ? (string)(int)$params['wrapuptime'] : '0';
-		$_REQUEST['weight'] = isset($params['weight']) ? (string)(int)$params['weight'] : '0';
-		$_REQUEST['maxlen'] = (string)(int)($params['maxlen'] ?? 0);
-		$_REQUEST['joinempty'] = $params['joinempty'] ?? 'yes';
-		$_REQUEST['leavewhenempty'] = $params['leavewhenempty'] ?? 'no';
-		$_REQUEST['announceposition'] = $params['announce_position'] ?? 'no';
-		$_REQUEST['announceholdtime'] = $params['announce_holdtime'] ?? 'no';
-		$_REQUEST['announcefreq'] = '0';
-		$_REQUEST['min-announce'] = '15';
-		$_REQUEST['pannouncefreq'] = '0';
-		$_REQUEST['recording'] = $params['recording'] ?? 'dontcare';
-		$_REQUEST['autofill'] = $params['autofill'] ?? 'yes';
-		$_REQUEST['reportholdtime'] = 'no';
-		$_REQUEST['autopause'] = 'no';
-		$_REQUEST['autopausedelay'] = '0';
-		$_REQUEST['servicelevel'] = '60';
-		$_REQUEST['memberdelay'] = '0';
-		$_REQUEST['timeoutrestart'] = 'no';
-		$_REQUEST['skip_joinannounce'] = '';
-		$_REQUEST['answered_elsewhere'] = '0';
-		$_REQUEST['timeoutpriority'] = 'app';
-		$_REQUEST['penaltymemberslimit'] = '0';
-		$_REQUEST['rvolume'] = '';
-		$_REQUEST['rvol_mode'] = '';
-		$_REQUEST['autopausebusy'] = 'no';
-		$_REQUEST['autopauseunavail'] = 'no';
-		$_REQUEST['music'] = $params['mohclass'] ?? 'default';
-		$_REQUEST['rtone'] = 0;
+
+		foreach (self::$requestMap as $reqKey => [$curKey, $default, $paramKey]) {
+			if (array_key_exists($paramKey, $params)) {
+				$val = $params[$paramKey];
+			} elseif (array_key_exists($curKey, $current) && $current[$curKey] !== null) {
+				$val = $current[$curKey];
+			} else {
+				$val = $default;
+			}
+			$_REQUEST[$reqKey] = is_string($val) ? $val : (string)$val;
+		}
+
+		// autofill is the one field queues_add() stores as
+		// (!empty($_REQUEST['autofill'])) ? 'yes' : 'no' — the literal string 'no'
+		// is truthy there and would be written back as 'yes'. Blank it to mean no.
+		$autofill = $params['autofill'] ?? ($current['autofill'] ?? 'yes');
+		$_REQUEST['autofill'] = ($autofill === 'no' || $autofill === '' || $autofill === '0') ? '' : 'yes';
+
+		foreach (self::$preserveOnly as $reqKey => $curKey) {
+			if (array_key_exists($curKey, $current) && $current[$curKey] !== null && $current[$curKey] !== '') {
+				$_REQUEST[$reqKey] = (string)$current[$curKey];
+			}
+		}
+
+		// MoH: 'inherit' makes queues_add skip the music row entirely. A queue with
+		// no music keyword is inheriting, so preserve that rather than pinning it
+		// to an explicit 'default'.
+		if (array_key_exists('mohclass', $params)) {
+			$_REQUEST['music'] = (string)$params['mohclass'];
+		} elseif (array_key_exists('music', $current)) {
+			$_REQUEST['music'] = (string)$current['music'];
+		} else {
+			$_REQUEST['music'] = empty($current) ? 'default' : 'inherit';
+		}
+
 		return $prior;
 	}
 
 	// Core writer used by Add + Update + member tools. All inputs already
 	// validated by the caller. Pre-populates $_REQUEST around queues_add().
-	public static function writeQueue($freepbx, array $args) {
+	//
+	// $current is queues_get() output on the UPDATE path, empty on create. The
+	// positional args below are the second place a queue's settings can be lost:
+	// they are NOT read from $_REQUEST, so hardcoding them reset agent/join
+	// announcements, call confirm and monitoring on every edit. Each now falls
+	// back to the current value, and to the original literal when $current is
+	// empty — so create is unchanged.
+	public static function writeQueue($freepbx, array $args, array $current = []) {
 		$freepbx->Modules->loadFunctionsInc('queues');
 		if (!function_exists('queues_add')) throw new \Exception('queues_add() not available — Queues module not loaded');
-		$prior = self::applyRequest($args);
+
+		// cur(key, literal): current value if the queue has one, else the literal.
+		$cur = function ($key, $literal) use ($current) {
+			if (!array_key_exists($key, $current) || $current[$key] === null || $current[$key] === '') return $literal;
+			return (string)$current[$key];
+		};
+
+		// queues_add() derives ringinuse from cwignore (2 or 3 => ringinuse 'no'),
+		// so carrying cwignore through is what preserves ringinuse. There is no way
+		// to set ringinuse independently through this path.
+		$agentannounce = $cur('agentannounce_id', null);
+		$joinannounce  = $cur('joinannounce_id', null);
+
+		// dynmembers must be an array — queues_add()'s '' default crashes array_unique.
+		$dynmembers = (isset($current['dynmembers']) && is_array($current['dynmembers'])) ? $current['dynmembers'] : [];
+
+		$prior = self::applyRequest($args, $current);
 		try {
 			queues_add(
 				$args['account'],
@@ -163,25 +243,25 @@ class AddQueue extends AbstractTool {
 				(string)($args['password'] ?? ''),
 				(string)($args['prefix'] ?? ''),
 				(string)($args['fail_destination'] ?? ''),
-				null,                                        // agentannounce_id
+				$agentannounce,
 				$args['members'] ?? [],
-				null,                                        // joinannounce_id
+				$joinannounce,
 				isset($args['maxwait']) ? (string)(int)$args['maxwait'] : '0',
 				(string)($args['alertinfo'] ?? ''),
-				'0',                                         // cwignore
-				'',                                          // qregex
-				'0',                                         // queuewait
-				'0',                                         // use_queue_context
-				[],                                          // dynmembers — queues_add() default '' crashes array_unique
-				'no',                                        // dynmemberonly
-				'0',                                         // togglehint
-				'0',                                         // qnoanswer
-				'0',                                         // callconfirm
-				'',                                          // callconfirm_id
-				'',                                          // monitor_type
-				'0',                                         // monitor_heard
-				'0',                                         // monitor_spoken
-				'0'                                          // answered_elsewhere
+				$cur('cwignore', '0'),
+				$cur('qregex', ''),
+				$cur('queuewait', '0'),
+				$cur('use_queue_context', '0'),
+				$dynmembers,
+				$cur('dynmemberonly', 'no'),
+				$cur('togglehint', '0'),
+				$cur('qnoanswer', '0'),
+				$cur('callconfirm', '0'),
+				$cur('callconfirm_id', ''),
+				$cur('monitor_type', ''),
+				$cur('monitor_heard', '0'),
+				$cur('monitor_spoken', '0'),
+				$cur('answered_elsewhere', '0')
 			);
 		} finally {
 			$_REQUEST = $prior;

--- a/Tools/AddQueueMember.php
+++ b/Tools/AddQueueMember.php
@@ -70,37 +70,30 @@ class AddQueueMember extends AbstractTool {
 		} finally {
 			$_REQUEST = $prior;
 		}
-		AddQueue::writeQueue($this->freepbx, $merged);
+		AddQueue::writeQueue($this->freepbx, $merged, $current);
 
 		return ['dry_run' => false, 'message' => "✅ Extension `{$extSan}` added to queue `{$accountSan}` `{$nameSan}` (penalty {$penalty}). Queue now has " . count($members) . " static member(s).", 'queue' => $account, 'ext' => $ext, 'penalty' => $penalty, 'needs_reload' => true];
 	}
 }
 
 // Shared helper for member add/remove tools. Builds the queues_add() args bag
-// from a queues_get() snapshot, preserving every settable field. Same field
-// list UpdateQueue::buildMerged uses; kept in this file rather than on
-// AddQueue to avoid bloating that class with edit-only plumbing.
+// from a queues_get() snapshot. Kept in this file rather than on AddQueue to
+// avoid bloating that class with edit-only plumbing.
 class UpdateQueueMemberHelper {
+	// Only the positional args of queues_add() belong here. Everything else is
+	// left out on purpose so writeQueue($freepbx, $merged, $current) reads it back
+	// out of $current — changing a queue's membership must not touch its settings.
+	// (Re-listing fields here re-introduced the old clobber: (int) on a retry of
+	// "none" became 0, and an inheriting MoH was pinned to "default".)
 	public static function buildMergedFromCurrent(array $current, $account) {
 		return [
-			'account'         => (string)$account,
-			'name'            => (string)($current['name'] ?? ''),
-			'password'        => (string)($current['password'] ?? ''),
-			'prefix'          => (string)($current['prefix'] ?? ''),
-			'fail_destination'=> (string)($current['goto'] ?? ''),
-			'alertinfo'       => (string)($current['alertinfo'] ?? ''),
-			'maxwait'         => (int)($current['maxwait'] ?? 0),
-			'strategy'        => (string)($current['strategy'] ?? 'ringall'),
-			'timeout'         => (int)($current['timeout'] ?? 15),
-			'retry'           => (int)($current['retry'] ?? 5),
-			'wrapuptime'      => (int)($current['wrapuptime'] ?? 0),
-			'weight'          => (int)($current['weight'] ?? 0),
-			'joinempty'       => (string)($current['joinempty'] ?? 'yes'),
-			'leavewhenempty'  => (string)($current['leavewhenempty'] ?? 'no'),
-			'announce_position' => (string)($current['announce-position'] ?? 'no'),
-			'announce_holdtime' => (string)($current['announce-holdtime'] ?? 'no'),
-			'recording'       => (string)($current['recording'] ?? 'dontcare'),
-			'mohclass'        => (string)($current['music'] ?? 'default'),
+			'account'          => (string)$account,
+			'name'             => (string)($current['name'] ?? ''),
+			'password'         => (string)($current['password'] ?? ''),
+			'prefix'           => (string)($current['prefix'] ?? ''),
+			'fail_destination' => (string)($current['goto'] ?? ''),
+			'alertinfo'        => (string)($current['alertinfo'] ?? ''),
+			'maxwait'          => (int)($current['maxwait'] ?? 0),
 		];
 	}
 }

--- a/Tools/RemoveQueueMember.php
+++ b/Tools/RemoveQueueMember.php
@@ -61,7 +61,7 @@ class RemoveQueueMember extends AbstractTool {
 		} finally {
 			$_REQUEST = $prior;
 		}
-		AddQueue::writeQueue($this->freepbx, $merged);
+		AddQueue::writeQueue($this->freepbx, $merged, $current);
 
 		return ['dry_run' => false, 'message' => "✅ Extension `{$extSan}` removed from queue `{$accountSan}` `{$nameSan}`. Queue now has " . count($filtered) . " static member(s).", 'queue' => $account, 'ext' => $ext, 'needs_reload' => true];
 	}

--- a/Tools/UpdateQueue.php
+++ b/Tools/UpdateQueue.php
@@ -9,7 +9,7 @@ require_once __DIR__ . '/AddQueue.php';
 // fields are preserved.
 class UpdateQueue extends AbstractTool {
 	public function name() { return 'fm_update_queue'; }
-	public function description() { return 'Update an existing call queue. Params: account (required). Any subset of name, strategy, timeout, retry, maxwait, fail_destination, mohclass, password, prefix, alertinfo, wrapuptime, weight, joinempty, leavewhenempty, announce_position, announce_holdtime, recording is merged in. members, if supplied, replaces the full member list (array of extension numbers or {ext, penalty} objects). Requires confirm:true.'; }
+	public function description() { return 'Update an existing call queue in place. Params: account (required). Any subset of name, strategy, timeout, retry, maxwait, fail_destination, mohclass, password, prefix, alertinfo, wrapuptime, weight, joinempty, leavewhenempty, announce_position, announce_holdtime, recording is merged in. members, if supplied, replaces the full member list (array of extension numbers or {ext, penalty} objects). Every setting you do NOT name is read back from the queue and preserved — including the ones this tool has no parameter for (service level, member delay, announce frequencies, autofill, ring-in-use, agent/join announcements, call confirm, monitoring, auto-pause). Requires confirm:true.'; }
 
 	public function validate($params) {
 		if (empty($params['account'])) return 'Parameter "account" is required';
@@ -20,29 +20,36 @@ class UpdateQueue extends AbstractTool {
 	public function requiredPermission() { return null; }
 	public function permissionLevel() { return self::PERM_WRITE; }
 
-	// Coerce queues_get() output into the args shape writeQueue() expects, then
-	// overlay caller-supplied params. Anything not supplied is preserved.
+	// Coerce queues_get() output into the args shape writeQueue() expects.
+	//
+	// Only two kinds of field belong here:
+	//   1. the positional args of queues_add(), which must always be supplied;
+	//   2. fields the caller actually named.
+	// Everything else is deliberately LEFT OUT so applyRequest()/writeQueue() fall
+	// back to the queue's current value. Naming a field here that the caller did
+	// not pass is how the old version silently rewrote it — e.g. (int)'none' on a
+	// retry of "none" quietly became 0.
 	private function buildMerged(array $current, array $params) {
 		$merged = [
-			'account'         => $params['account'],
-			'name'            => isset($params['name']) ? trim((string)$params['name']) : (string)($current['name'] ?? ''),
-			'password'        => isset($params['password']) ? (string)$params['password'] : (string)($current['password'] ?? ''),
-			'prefix'          => isset($params['prefix']) ? (string)$params['prefix'] : (string)($current['prefix'] ?? ''),
-			'fail_destination'=> isset($params['fail_destination']) ? (string)$params['fail_destination'] : (string)($current['goto'] ?? ''),
-			'alertinfo'       => isset($params['alertinfo']) ? (string)$params['alertinfo'] : (string)($current['alertinfo'] ?? ''),
-			'maxwait'         => isset($params['maxwait']) ? (int)$params['maxwait'] : (int)($current['maxwait'] ?? 0),
-			'strategy'        => $params['strategy'] ?? ($current['strategy'] ?? 'ringall'),
-			'timeout'         => isset($params['timeout']) ? (int)$params['timeout'] : (int)($current['timeout'] ?? 15),
-			'retry'           => isset($params['retry']) ? (int)$params['retry'] : (int)($current['retry'] ?? 5),
-			'wrapuptime'      => isset($params['wrapuptime']) ? (int)$params['wrapuptime'] : (int)($current['wrapuptime'] ?? 0),
-			'weight'          => isset($params['weight']) ? (int)$params['weight'] : (int)($current['weight'] ?? 0),
-			'joinempty'       => $params['joinempty'] ?? ($current['joinempty'] ?? 'yes'),
-			'leavewhenempty'  => $params['leavewhenempty'] ?? ($current['leavewhenempty'] ?? 'no'),
-			'announce_position' => $params['announce_position'] ?? ($current['announce-position'] ?? 'no'),
-			'announce_holdtime' => $params['announce_holdtime'] ?? ($current['announce-holdtime'] ?? 'no'),
-			'recording'       => $params['recording'] ?? ($current['recording'] ?? 'dontcare'),
-			'mohclass'        => $params['mohclass'] ?? ($current['music'] ?? 'default'),
+			'account'          => $params['account'],
+			'name'             => isset($params['name']) ? trim((string)$params['name']) : (string)($current['name'] ?? ''),
+			'password'         => isset($params['password']) ? (string)$params['password'] : (string)($current['password'] ?? ''),
+			'prefix'           => isset($params['prefix']) ? (string)$params['prefix'] : (string)($current['prefix'] ?? ''),
+			'fail_destination' => isset($params['fail_destination']) ? (string)$params['fail_destination'] : (string)($current['goto'] ?? ''),
+			'alertinfo'        => isset($params['alertinfo']) ? (string)$params['alertinfo'] : (string)($current['alertinfo'] ?? ''),
+			'maxwait'          => isset($params['maxwait']) ? (int)$params['maxwait'] : (int)($current['maxwait'] ?? 0),
 		];
+
+		// Integer-typed fields: cast only what the caller supplied.
+		foreach (['timeout', 'retry', 'wrapuptime', 'weight'] as $f) {
+			if (isset($params[$f])) $merged[$f] = (int)$params[$f];
+		}
+		// Pass-through fields: forward only what the caller supplied.
+		foreach (['strategy', 'joinempty', 'leavewhenempty', 'announce_position',
+		          'announce_holdtime', 'recording', 'mohclass'] as $f) {
+			if (isset($params[$f])) $merged[$f] = $params[$f];
+		}
+
 		return $merged;
 	}
 
@@ -143,7 +150,9 @@ class UpdateQueue extends AbstractTool {
 			$_REQUEST = $prior;
 		}
 
-		AddQueue::writeQueue($this->freepbx, $merged);
+		// $current is what makes this an edit rather than a re-create: every field
+		// the caller didn't name is read back out of it instead of being reset.
+		AddQueue::writeQueue($this->freepbx, $merged, $current);
 
 		return ['dry_run' => false, 'message' => "✅ Queue `{$accountSan}` `{$nameSan}` updated (" . count($diff) . " field(s) changed).", 'account' => $account, 'needs_reload' => true];
 	}


### PR DESCRIPTION
## The bug

`fm_update_queue` rebuilds a queue with `queues_del` + `queues_add`. `queues_add()` takes its config from two places: ~30 keys it reads out of `$_REQUEST`, and ~15 positional args. `AddQueue::applyRequest()` hardcoded the first group and `AddQueue::writeQueue()` the second — so any setting the tool has no parameter for was written back as a default on every edit.

Renaming a queue also reset announce frequencies, service level, member delay, autofill, ring-in-use, agent/join announcements, call confirm, monitoring and auto-pause.

`fm_add_queue_member` and `fm_remove_queue_member` call the same writer, so **adding an agent to a queue did it too** — that one is easy to hit in normal use.

Minimal reproduction on a stock queue:

```
# announce-frequency is 25
fwconsole frogman:tool fm_update_queue '{"account":"9099","name":"Renamed","confirm":true}'
# announce-frequency is now 0
```

## The fix

`applyRequest()` and `writeQueue()` take an optional `$current` (the `queues_get()` snapshot, which already returns all ~65 keys) and resolve each field as **explicit param > current value > the original literal**. `fm_update_queue` and the two member tools pass it; `fm_add_queue` doesn't, so with no snapshot every field collapses to the literal and creation is unchanged.

`UpdateQueue::buildMerged()` and the member-tool helper now list only the `queues_add` positional args plus what the caller actually passed. Re-listing the rest was itself a clobber — it cast a `retry` of `"none"` to `0`, and pinned an inheriting MoH class to `"default"`.

Three FreePBX behaviours are documented in comments rather than worked around:

- `ringinuse` is derived from the `cwignore` positional (2 or 3 → `no`), so carrying `cwignore` through is what preserves it. There's no way to set it independently through this path.
- The `queue-youarenext` / `thereare` / `callswaiting` / `thankyou` prompts are derived from `announceposition`.
- `autofill` is stored via `(!empty($_REQUEST['autofill'])) ? 'yes' : 'no'`, so the string `'no'` is truthy there and has to be blanked to mean no.

The `$_REQUEST` key map is written out in full because the request names and the stored keyword names differ (`announcefreq` → `announce-frequency`, `pannouncefreq` → `periodic-announce-frequency`), which is what made the drops easy to miss in the first place.

No new tools, no routing changes, no version bump. Still BMO/`queues_add`-only — no new DB writes.

## Testing

FreePBX 17.0.30 / Asterisk 18, real box. 23 assertions, all passing.

**Create path is unchanged** — created a queue with the old code, dumped `queues_details` + `queues_config`, then created the identical queue after the change and diffed. Both tables byte-identical, 39 keywords either way.

**The bug is fixed** — seeded 10 non-default values in fields `fm_update_queue` has no parameter for, then renamed the queue only:

```
fwconsole frogman:tool fm_add_queue '{"account":"9099","name":"ClobberTest","strategy":"linear","timeout":20,"retry":6,"maxwait":300,"members":["110"],"confirm":true}'
# seed announce-frequency=25, servicelevel=75, reportholdtime=yes, autofill=no,
# periodic-announce-frequency=45, penaltymemberslimit=3, timeoutrestart=yes,
# memberdelay=30, min-announce-frequency=90, retry=none
fwconsole frogman:tool fm_update_queue '{"account":"9099","name":"ClobberTest-RENAMED","confirm":true}'
```

39 keyword rows before, 39 after, full `queues_details` diff empty. `retry` stayed `none` rather than becoming `0`.

**Named fields still change** — `fwconsole frogman:tool fm_update_queue '{"account":"9099","strategy":"rrmemory","joinempty":"no","servicelevel":"120","confirm":true}'` applied all three, and `announce-frequency` stayed at 25.

**Member tools** — `fm_add_queue_member` then `fm_remove_queue_member`; settings diff empty both times, membership changed correctly.

Two caveats on coverage, so the numbers aren't over-read:

- The `preserveOnly` branch (`eventwhencalled`, `eventmemberstatus`, `announcemenu`, `callback`) didn't execute — a freshly created queue has those at values its guard skips. Worst case they behave as they did before this change.
- `ringinuse` preservation follows from `cwignore` now being passed through, but no test exercised it directly; seeding `ringinuse=no` with `cwignore=0` would be a state the GUI can't produce.

Happy to add tests or split this differently if you'd prefer. Per CONTRIBUTING: I used Claude while writing this, and kept it out of the commit trailers.