### PR TITLE
Prevent API 17 dependency install attempts on unsupported FreePBX versions

### DIFF
--- a/Tools/RunSavedQuery.php
+++ b/Tools/RunSavedQuery.php
@@ -33,6 +33,11 @@ class RunSavedQuery extends AbstractTool {
 	public function execute($params, $context) {
 		$name = $params['name'];
 		$variables = $params['params'] ?? [];
+		$apiInfo = \module_functions::create()->getinfo('api', MODULE_STATUS_ENABLED);
+		$apiVersion = $apiInfo['api']['dbversion'] ?? null;
+		if (!$apiVersion || version_compare($apiVersion, '17.0.1', '<')) {
+			return ['error' => 'Saved GraphQL queries require the optional FreePBX API module 17.0.1+ to be installed and enabled.'];
+		}
 
 		$db = $this->freepbx->Database;
 

--- a/Tools/SaveQuery.php
+++ b/Tools/SaveQuery.php
@@ -38,14 +38,20 @@ class SaveQuery extends AbstractTool {
 		$paramSpec = $params['param_spec'] ?? '{}';
 
 		// Validate the GraphQL query parses
+		$apiInfo = \module_functions::create()->getinfo('api', MODULE_STATUS_ENABLED);
+		$apiVersion = $apiInfo['api']['dbversion'] ?? null;
+		if (!$apiVersion || version_compare($apiVersion, '17.0.1', '<')) {
+			return ['error' => 'Saved GraphQL queries require the optional FreePBX API module 17.0.1+ to be installed and enabled.'];
+		}
 		$autoloadPath = '/var/www/html/admin/modules/api/vendor/autoload.php';
-		if (file_exists($autoloadPath)) {
-			require_once $autoloadPath;
-			try {
-				\GraphQL\Language\Parser::parse($query);
-			} catch (\Exception $e) {
-				throw new \Exception("GraphQL parse error: " . $e->getMessage());
-			}
+		if (!file_exists($autoloadPath)) {
+			return ['error' => 'Saved GraphQL queries require the optional FreePBX API module 17.0.1+ to be installed and enabled.'];
+		}
+		require_once $autoloadPath;
+		try {
+			\GraphQL\Language\Parser::parse($query);
+		} catch (\Exception $e) {
+			throw new \Exception("GraphQL parse error: " . $e->getMessage());
 		}
 
 		// Validate param_spec is valid JSON if provided

--- a/install.php
+++ b/install.php
@@ -1,5 +1,11 @@
 <?php
 if (!defined('FREEPBX_IS_AUTH')) { die('No direct script access allowed'); }
+
+if (version_compare(getversion(), '17.0', '<')) {
+	out(_('Frogman requires FreePBX 17 or later. Installation aborted.'));
+	return false;
+}
+
 // Schema is defined in module.xml <database> blocks.
 // This file is reserved for feature codes, kvstore defaults, or data migrations.
 // Migrations are written to be idempotent so install.php is safe to re-run.

--- a/module.xml
+++ b/module.xml
@@ -117,8 +117,7 @@
 		*1.1.0* Add fm_whos_on_the_phone (212 tools); fix ChatParser OOM from recursive synonym expansion on "create inbound route"; route questions ending with "?" to KB search; security: shell injection fix in FwconsoleCmd, AMI allowlist, input sanitization; tool prefix oc_ → fm_
 		*1.0.0* Initial release: 211 tools, MCP server, web console, CLI chat, knowledge base RAG, call flow visualizer, API token auth
 	]]></changelog>	<depends>
-		<version>17.0.1</version>
-		<module>api ge 17.0.1</module>
+		<version>17.0</version>
 	</depends>
 	<database>
 		<table name="oc_audit_log">


### PR DESCRIPTION
## What this is

This PR prevents the FreePBX Framework dependency resolver from attempting to install FreePBX 17-only API dependencies on unsupported FreePBX 15 and 16 systems before Frogman itself is rejected.

`module.xml` now declares FreePBX 17.0+ as the platform requirement without making the API module a hard install-time dependency.

The two saved GraphQL-query tools now check for an installed and enabled API module 17.0.1+ at runtime.

`install.php` also includes an early defensive FreePBX version guard before any Frogman database or migration work.

This is a four-file install-safety change. There are no schema changes, version bump, changelog changes or README changes.

## Why

Current Frogman v2.9.1 declares:

```xml
<version>17.0.1</version>
<module>api ge 17.0.1</module>
```

On FreePBX 15 and 16, Framework attempts to satisfy the API dependency before it ultimately rejects Frogman for requiring FreePBX 17.

On FreePBX 16.0.50, the current release produces:

```text
Detected Missing Dependency of: api 17.0.1
Downloading Missing Dependency of: api 17.0.1
...
Installing Missing Dependency of: api 17.0.1
...
Installed Missing Dependency of: api 17.0.1
Dependency module api version 17.0.1 is Enabled
Unable to install module frogman:
 - FreePBX version 17.0.1 or higher is required, you have 16.0.50
 - PBX API module version 17.0.1 or higher is required, you have 16.0.18
```

The same dependency-resolution behaviour was reproduced on FreePBX 15.0.38.

This is also unnecessarily alarming from an operator perspective. Seeing Framework announce that it is downloading and installing a FreePBX 17 dependency on a FreePBX 15 or 16 host gives the operator no confidence that the unsupported installation attempt has left the system untouched.

On FreePBX 15.0.38, the dependency path explicitly cleared and repopulated the existing API module's Node dependency tree before Frogman was rejected:

```text
[npm-cache] [INFO] [npm] clearing installed dependencies at /var/www/html/admin/modules/api/node/node_modules
[npm-cache] [INFO] [npm] ...cleared
[npm-cache] [INFO] [npm] retrieving dependencies from /home/asterisk/.package_cache/...
[npm-cache] [INFO] [npm] done extracting
[npm-cache] [INFO] successfully installed all dependencies
```

The API module remained registered as 15.0.13 afterwards.

On FreePBX 16.0.50, API likewise remained registered as 16.0.18 while fresh API Node/runtime/generated artefacts were written during the dependency attempt.

## Root cause

The FreePBX platform dependency does not stop older Framework versions from first attempting to satisfy the hard `api >= 17.0.1` module dependency.

API is optional for Frogman's core operation. It is used by the API GraphQL adapter and saved GraphQL-query functionality; this PR adds explicit runtime checks to the two saved-query tools that directly require it.

This PR therefore removes API from Frogman's hard module dependencies and checks for it only when the saved GraphQL-query tools are used.

## Behaviour

Frogman installation:

* FreePBX 15 and 16 download/extract Frogman for metadata inspection, then reject it on the FreePBX 17 platform requirement without entering API dependency resolution
* FreePBX 17.0.33 installed, completed migrations, reloaded, and enabled Frogman successfully
* the defensive `install.php` guard independently blocks versions below 17
* that guard executes before `FreePBX::Database()` or any Frogman migration work

Saved GraphQL-query tools:

* require the API module to be installed and enabled
* require API 17.0.1+
* return a clear error when API is absent, disabled or too old
* continue normally when API 17.0.1+ is available

Other Frogman functionality remains independent of the API module.

## Compatibility

The FreePBX platform dependency is now:

```xml
<depends>
    <version>17.0</version>
</depends>
```

The matching defensive installer guard is:

```php
if (version_compare(getversion(), '17.0', '<')) {
    out(_('Frogman requires FreePBX 17 or later. Installation aborted.'));
    return false;
}
```

The saved GraphQL-query tools retain their API 17.0.1+ requirement at runtime.

## Test plan

### Current upstream on FreePBX 16.0.50

Installed current Frogman v2.9.1 using:

```bash
URL=$(curl -s https://api.github.com/repos/mwtcmi/frogman/releases/latest | grep browser_download_url | grep '\.tgz' | cut -d'"' -f4)

fwconsole ma downloadinstall "$URL"
```

Confirmed Framework detected, downloaded and ran the API 17.0.1 dependency installer before Frogman was rejected.

The existing API module remained registered as 16.0.18 afterwards.

### This branch on FreePBX 16.0.50

Installed this branch using:

```bash
URL="https://github.com/kierknoby/frogman_int-dev/archive/refs/heads/block-below-v17.tar.gz"

fwconsole ma downloadinstall "$URL"
```

Result:

```text
Unable to install module frogman:
 - FreePBX version 17.0 or higher is required, you have 16.0.50
```

Confirmed there was no API 17 dependency-resolution attempt.

### Current upstream on FreePBX 15.0.38

Installed current Frogman v2.9.1 using the same release installation path.

Confirmed Framework again attempted to install API 17.0.1 before rejecting Frogman.

The dependency path explicitly cleared and repopulated the existing API Node dependency tree.

Frogman was then rejected with:

```text
Unable to install module frogman:
 - FreePBX version 17.0.1 or higher is required, you have 15.0.38
 - PBX API module version 17.0.1 or higher is required, you have 15.0.13
```

The API module remained registered as 15.0.13.

The test system was restored afterwards by force-reinstalling API 15.0.13 and deleting the locally extracted Frogman copy.

### This branch on FreePBX 15.0.38

Installed this branch using the same `fwconsole ma downloadinstall` path.

Result:

```text
Unable to install module frogman:
 - FreePBX version 17.0 or higher is required, you have 15.0.38
```

Confirmed there was no API 17 dependency-resolution attempt.

### This branch on FreePBX 17.0.33

Installed this branch on a real FreePBX 17.0.33 system using:

```bash
fwconsole --version

URL="https://github.com/kierknoby/frogman_int-dev/archive/refs/heads/block-below-v17.tar.gz"

fwconsole ma downloadinstall "$URL"

fwconsole reload

fwconsole ma list | grep frogman
```

Result:

```text
FW Console - FreePBX Utility 17.0.33
...
Module frogman version 2.9.1 successfully installed
...
Reload Complete
| frogman | 2.9.1 | Enabled | AGPLv3 | Unsigned |
```

Confirmed:

* Frogman installs successfully on FreePBX 17.0.33
* Frogman migrations complete normally
* `fwconsole reload` completes successfully
* Frogman is enabled after installation

### Focused installer simulations

The committed `install.php` was exercised with:

* FreePBX 15.0.38: exact rejection message and `return false` before migrations
* FreePBX 16.0.50: exact rejection message and `return false` before migrations
* FreePBX 17.0: platform guard passes and reaches the first database/migration boundary

### Optional API checks

The saved-query tools were exercised using FreePBX's nested `getinfo()` result shape.

Confirmed:

* API absent: rejected cleanly
* API disabled / filtered out: rejected cleanly
* API 17.0.0: rejected cleanly
* API 17.0.1: passes the runtime metadata check

## Validation

The repository has no general PHP test suite, Composer configuration, PHPUnit configuration, Makefile or standalone lint workflow applicable to these files.

The following checks pass:

```bash
php -l install.php
php -l Tools/SaveQuery.php
php -l Tools/RunSavedQuery.php
git diff HEAD^ --check
git show --check HEAD
```

The worktree is clean.

`fm_lint_typeahead` is not applicable because this PR does not change chat parser anchors or typeahead behaviour.

## What's deliberately not in this PR

* no Frogman version bump
* no changelog change
* no README change
* no change to GraphQL behaviour when a suitable API module is available
* no changes to non-GraphQL Frogman tools
* no attempt to support Frogman on FreePBX 15 or 16
* no Framework-level cleanup change for downloaded-but-rejected modules

## Files changed

* `module.xml`
* `install.php`
* `Tools/SaveQuery.php`
* `Tools/RunSavedQuery.php`
